### PR TITLE
v0.1.1 - Change `oven` to `Oven`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. This projec
 **Full Changelog**: https://github.com/homebridge-plugins/homebridge-smarthq/compare/v0.1.0...v1.0.0
 
 ## [0.1.0](https://github.com/homebridge-plugins/homebridge-smarthq/releases/tag/v0.1.0) (2024-09-07)
+## 0.1.1: Change "oven" to "Oven"
 
 ### What's Changes
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@homebridge-plugins/homebridge-smarthq",
   "displayName": "SmartHQ",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The SmartHQ plugin allows you to interact with SmartHQ Devices in HomeKit and with Siri.",
   "author": {
     "name": "donavanbecker",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -233,7 +233,7 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
           case 'Dishwasher':
             await this.createSmartHQDishWasher(userId, device, details, features)
             break
-          case 'oven':
+          case 'Oven':
             await this.createSmartHQOven(userId, device, details, features)
             break
           default:


### PR DESCRIPTION
## :recycle: Current situation

Getting this log w/ the current plugin:

```bash
Device Type Not Supported: Oven
```

Checked the code and saw that it was case sensitive.