### PR TITLE
Favor deviceOptions over options for options that are specific to devices.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@homebridge-plugins/homebridge-smarthq",
-  "version": "0.3.0",
+  "version": "0.4.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@homebridge-plugins/homebridge-smarthq",
-      "version": "0.3.0",
+      "version": "0.4.0-beta.2",
       "funding": [
         {
           "type": "Paypal",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@homebridge-plugins/homebridge-smarthq",
-  "version": "0.4.0-beta.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@homebridge-plugins/homebridge-smarthq",
-      "version": "0.4.0-beta.2",
+      "version": "0.3.0",
       "funding": [
         {
           "type": "Paypal",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@homebridge-plugins/homebridge-smarthq",
   "displayName": "SmartHQ",
   "type": "module",
-  "version": "0.4.0-beta.2",
+  "version": "0.3.0",
   "description": "The SmartHQ plugin allows you to interact with SmartHQ Devices in HomeKit and with Siri.",
   "author": {
     "name": "donavanbecker",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@homebridge-plugins/homebridge-smarthq",
   "displayName": "SmartHQ",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.4.0-beta.2",
   "description": "The SmartHQ plugin allows you to interact with SmartHQ Devices in HomeKit and with Siri.",
   "author": {
     "name": "donavanbecker",

--- a/src/devices/OpalIceMaker/Managers/OpalFilterMaintenanceSvcManager.ts
+++ b/src/devices/OpalIceMaker/Managers/OpalFilterMaintenanceSvcManager.ts
@@ -20,7 +20,7 @@ export class OpalFilterMaintenanceSvcManager extends OpalDeviceBase {
       return this.filterMaintenanceStatus
     }).on('change', async (chg) => {
       if (chg.oldValue === this.platform.Characteristic.FilterChangeIndication.FILTER_OK && chg.newValue === this.platform.Characteristic.FilterChangeIndication.CHANGE_FILTER) {
-        const notificationPath = this.platform.config.options?.oplHKCFilterMaintenanceNotificationPath
+        const notificationPath = this.platform.config.deviceOptions?.opal?.oplHKCFilterMaintenanceNotificationPath
         if (notificationPath) {
           await this.sendHomeKitControllerNotification(notificationPath)
         }

--- a/src/devices/OpalIceMaker/Managers/OpalMetadataSvcManager.ts
+++ b/src/devices/OpalIceMaker/Managers/OpalMetadataSvcManager.ts
@@ -17,11 +17,11 @@ export class OpalMetadataSvcManager extends OpalDeviceBase {
     // Get default accessory information service
     this.service = this.accessory.getService('')!
     // Metadata for Device Form, Opal Production Limit
-    const opalProductionLimitQueryStr = 'l=Production_Duration_Minutes&i=opalProductionLimit&t=number&d=0&p=Number._0_for_Infinite'
-    const opalHKCNotificationsPathQueryStr = 'l=HKC_Ice_Bucket_Full_Notification_Path&i=oplHKCIceBucketFullNotificationPath'
-    const opalHKCCompletionNotificationPathQueryStr = 'l=HKC_Progress_Complete_Notification_Path&i=oplHKCProgressCompleteNotificationPath'
-    const opalHKCFilterMaintenanceNotificationPathQueryStr = 'l=HKC_Filter_Maintenace_Notification_Path&i=oplHKCFilterMaintenanceNotificationPath'
-    const opalHKCAddWaterNotificationPathQueryStr = 'l=HKC_Add_Water_Notification_Path&i=oplHKCAddWaterNotificationPath'
+    const opalProductionLimitQueryStr = 'l=Production_Duration_Minutes&i=opalProductionLimit&t=number&d=0&p=Number._0_for_Infinite&de=opal'
+    const opalHKCNotificationsPathQueryStr = 'l=HKC_Ice_Bucket_Full_Notification_Path&i=oplHKCIceBucketFullNotificationPath&de=opal'
+    const opalHKCCompletionNotificationPathQueryStr = 'l=HKC_Progress_Complete_Notification_Path&i=oplHKCProgressCompleteNotificationPath&de=opal'
+    const opalHKCFilterMaintenanceNotificationPathQueryStr = 'l=HKC_Filter_Maintenace_Notification_Path&i=oplHKCFilterMaintenanceNotificationPath&de=opal'
+    const opalHKCAddWaterNotificationPathQueryStr = 'l=HKC_Add_Water_Notification_Path&i=oplHKCAddWaterNotificationPath&de=opal'
 
     const fullQueryStr = [
       opalProductionLimitQueryStr,

--- a/src/devices/OpalIceMaker/Managers/OpalMetadataSvcManager.ts
+++ b/src/devices/OpalIceMaker/Managers/OpalMetadataSvcManager.ts
@@ -40,6 +40,7 @@ export class OpalMetadataSvcManager extends OpalDeviceBase {
     this.service
       ?.getCharacteristic(this.platform.Characteristic.ProductData)
       .onGet(() => fullQueryStr)
+      .updateValue(fullQueryStr)
   }
 
   getService(): Service {

--- a/src/devices/OpalIceMaker/Managers/OpalProgressSvcManager.ts
+++ b/src/devices/OpalIceMaker/Managers/OpalProgressSvcManager.ts
@@ -19,9 +19,9 @@ export class OpalProgressSvcManager extends OpalDeviceBase {
   ) {
     super(platform, accessory, device)
 
-    if (platform.config.options?.opalProductionLimit) {
+    if (platform.config.deviceOptions?.opal?.opalProductionLimit) {
       this.createService()
-      this.opalProductionLimit = platform.config.options?.opalProductionLimit
+      this.opalProductionLimit = platform.config.deviceOptions.opal.opalProductionLimit
     } else {
       // If the service exists but condition is false, remove it
       const existingService = this.accessory.getService(this.serviceName)
@@ -65,7 +65,7 @@ export class OpalProgressSvcManager extends OpalDeviceBase {
       .removeOnSet()
       .on('change', async (chg) => {
         if (chg.oldValue !== 100 && chg.newValue === 100) {
-          const notificationPath = this.platform.config.options?.oplHKCProgressCompleteNotificationPath
+          const notificationPath = this.platform.config.deviceOptions?.opal?.oplHKCProgressCompleteNotificationPath
           if (notificationPath) {
             await this.sendHomeKitControllerNotification(notificationPath)
           }

--- a/src/devices/OpalIceMaker/Managers/StatusManagers/OpalAddWaterStatusSvcManager.ts
+++ b/src/devices/OpalIceMaker/Managers/StatusManagers/OpalAddWaterStatusSvcManager.ts
@@ -29,7 +29,7 @@ export class OpalAddWaterStatusSvcManager extends OpalDeviceBase {
       .onGet(() => this.addWaterCurrentStatus)
       .on('change', async (chg) => {
         if (chg.oldValue === this.AddWaterCurrentStatus.WATER_OK && chg.newValue === this.AddWaterCurrentStatus.ADD_WATER) {
-          const notificationPath = this.platform.config.options?.oplHKCAddWaterNotificationPath
+          const notificationPath = this.platform.config.deviceOptions?.opal?.oplHKCAddWaterNotificationPath
 
           if (notificationPath) {
             await this.sendHomeKitControllerNotification(notificationPath)

--- a/src/devices/OpalIceMaker/Managers/StatusManagers/OpalIceBucketStatusSvcManager.ts
+++ b/src/devices/OpalIceMaker/Managers/StatusManagers/OpalIceBucketStatusSvcManager.ts
@@ -29,7 +29,7 @@ export class OpalIceBucketStatusSvcManager extends OpalDeviceBase {
       .onGet(() => this.iceBucketCurrentStatus)
       .on('change', async (chg) => {
         if (chg.oldValue === this.IceBucketFullStatus.ICE_BUCKET_NOT_FULL && chg.newValue === this.IceBucketFullStatus.ICE_BUCKET_FULL) {
-          const notificationPath = this.platform.config.options?.oplHKCIceBucketFullNotificationPath
+          const notificationPath = this.platform.config.deviceOptions?.opal?.oplHKCIceBucketFullNotificationPath
           if (notificationPath) {
             await this.sendHomeKitControllerNotification(notificationPath)
           }

--- a/src/homebridge-ui/public/index.html
+++ b/src/homebridge-ui/public/index.html
@@ -162,7 +162,7 @@
           const advancedOptions = thisAcc.services.filter((svc) => !!svc.characteristics.find((char) => char.displayName === 'Product Data'))
 
           if (advancedOptions.length) {
-            // currently only supporting one advanced option
+            // currently only supporting one accessory for now - opal
             const raw = advancedOptions[0].characteristics.find((char) => char.displayName === 'Product Data').value.split(',')
             raw.forEach((r) => {
               const tr = document.createElement('tr')
@@ -177,12 +177,12 @@
               const input = document.createElement('input')
               input.type = metadata.t
               input.placeholder = metadata.p?.replaceAll('_', ' ') || ''
-              const existingDefaultValue = metadata.t === 'number' ? Number(currentConfig[0].options?.[metadata.i]) : (currentConfig[0].options?.[metadata.i] ?? "")
+              const existingDefaultValue = metadata.t === 'number' ? Number(currentConfig[0].deviceOptions?.[metadata.de][metadata.i]) : (currentConfig[0].deviceOptions?.[metadata.de][metadata.i] ?? "")
 
               input.defaultValue = existingDefaultValue
               input.addEventListener('change', async () => {
                 const value = metadata.t === 'number' ? Number(event.target.value) : (event.target.value ?? "")
-                currentConfig[0].options = {...currentConfig[0].options, [metadata.i]: value }
+                currentConfig[0].deviceOptions[metadata.de] = {...currentConfig[0].deviceOptions[metadata.de], [metadata.i]: value }
                 await homebridge.updatePluginConfig([...currentConfig])
                 await homebridge.savePluginConfig();
               })

--- a/src/homebridge-ui/public/index.html
+++ b/src/homebridge-ui/public/index.html
@@ -177,12 +177,22 @@
               const input = document.createElement('input')
               input.type = metadata.t
               input.placeholder = metadata.p?.replaceAll('_', ' ') || ''
-              const existingDefaultValue = metadata.t === 'number' ? Number(currentConfig[0].deviceOptions?.[metadata.de][metadata.i]) : (currentConfig[0].deviceOptions?.[metadata.de][metadata.i] ?? "")
+              const existingDefaultValue = metadata.t === 'number' ? Number(currentConfig[0].deviceOptions?.[metadata.de]?.[metadata.i]) : (currentConfig[0].deviceOptions?.[metadata.de]?.[metadata.i] ?? "")
 
               input.defaultValue = existingDefaultValue
               input.addEventListener('change', async () => {
                 const value = metadata.t === 'number' ? Number(event.target.value) : (event.target.value ?? "")
-                currentConfig[0].deviceOptions[metadata.de] = {...currentConfig[0].deviceOptions[metadata.de], [metadata.i]: value }
+
+                currentConfig[0] = {
+                  ...currentConfig[0],
+                  deviceOptions: {
+                    ...currentConfig[0].deviceOptions,
+                    [metadata.de]: {
+                      ...currentConfig[0].deviceOptions?.[metadata.de],
+                      [metadata.i]: value
+                    }
+                  }
+                }
                 await homebridge.updatePluginConfig([...currentConfig])
                 await homebridge.savePluginConfig();
               })

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -70,6 +70,7 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
       credentials: config.credentials as credentials,
       devices: config.devices as devicesConfig[],
       options: config.options as options,
+      deviceOptions: config.deviceOptions
     }
 
     // Plugin Configuration

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,7 @@ export interface SmartHQPlatformConfig extends PlatformConfig {
   credentials?: credentials
   devices?: devicesConfig[]
   options?: options
+  deviceOptions?: DeviceOptions
 }
 
 export interface credentials {
@@ -56,12 +57,18 @@ export interface options {
   updateRate?: number
   pushRate?: number
   logging?: string
+  homekitControllerNotificationsSecret?: string
+}
+
+interface OpalOptions {
   opalProductionLimit?: number
   oplHKCIceBucketFullNotificationPath?: string
-  homekitControllerNotificationsSecret?: string
   oplHKCProgressCompleteNotificationPath?: string
   oplHKCFilterMaintenanceNotificationPath?: string
   oplHKCAddWaterNotificationPath?: string
+}
+export interface DeviceOptions {
+  opal?: OpalOptions
 }
 
 export interface SmartHqContext {


### PR DESCRIPTION
## :recycle: Current situation

I found that it took a long time for the device options to update after a refresh and also that one had to set advanced options before setting device options because they were overwritten if done first.

## :bulb: Proposed solution

created a separate deviceOptions object in the config to read and write from, also sets the value of the the service metadata on startup rather than waiting for the next natural update.

## :gear: Release Notes

DeviceOption Config IMprovements

## :heavy_plus_sign: Additional Information

Nothing

### Testing

Have tested with production value and ice bucket notifications

### Reviewer Nudging

The index.html file changes are interesting at least
