### PR TITLE
Opal Monitoring Services Improvements

### DIFF
--- a/src/devices/OpalIceMaker/Managers/OpalMonitorManager.ts
+++ b/src/devices/OpalIceMaker/Managers/OpalMonitorManager.ts
@@ -1,17 +1,16 @@
 import type { PlatformAccessory } from 'homebridge'
 import type { Subscription } from 'rxjs'
+import { timer, Observable, concat, of } from 'rxjs'
+import { switchMap, skipWhile } from 'rxjs'
 
 import { SmartHQIceMaker } from '@opal/index.js'
 import type { SmartHQPlatform, devicesConfig, SmartHqContext } from '@root'
-
-
-import { interval, skipWhile } from 'rxjs'
 import { OpalDeviceBase } from '@opal/OpalDeviceBase.js'
-
 
 export class OpalMonitorManager extends OpalDeviceBase {
   private servicesSubscription: Subscription | null = null
   private schedulerSubscription: Subscription | null = null
+  private statusSubscription: Subscription | null = null
   public opalIceMaker: SmartHQIceMaker
 
   constructor(
@@ -24,34 +23,91 @@ export class OpalMonitorManager extends OpalDeviceBase {
     this.opalIceMaker = opalIceMaker
   }
 
+  private getTimeUntilNextMinute(): number {
+    const now = new Date()
+    const remaining = (60 - now.getSeconds()) * 1000 - now.getMilliseconds()
+    return remaining > 0 ? remaining : 0
+  }
+
+  // Create a timer that aligns with the minute boundary and executes immediately at alignment
+  private createMinuteAlignedTimer(intervalMs: number): Observable<number> {
+    return timer(this.getTimeUntilNextMinute()).pipe(
+      // Start with an immediate emission, then continue with regular interval
+      switchMap(() => concat(
+        of(0), // Emit 0 immediately when the timer reaches alignment
+        timer(intervalMs, intervalMs)
+      ))
+    )
+  }
+
   // Start the monitoring
   startServicesMonitoring(): void {
     // Stop any existing subscription first
     this.stopServicesMonitoring()
-    this.stopSchedulerMonitoring()
 
-    this.servicesSubscription = interval((this.device.refreshRate || 30) * 1000)
-      .pipe(skipWhile(() => !this.opalIceMaker.progressManager && !this.platform.config.options?.homekitControllerNotificationsSecret))
-      .subscribe(async () => {
-        await this.opalIceMaker.statusManager.getOpalCurrentStatus()
-        await this.opalIceMaker.filterMaintenanceManager.getFilterMaintenanceStatus()
-        await this.opalIceMaker.descaleManager.getDescaleStatus()
-        if (this.opalIceMaker.progressManager?.hasService()) {
-          const currentProductionValue = await this.opalIceMaker.progressManager.processProductionProgress()
-          this.opalIceMaker.powerManager.turnOffOnProductionLimitSurpassed(currentProductionValue)
-        }
-      })
-    this.platform.debugLog(`Started ice maker monitoring at ${this.device.refreshRate}s intervals`)
+    const refreshRate = (this.platform.config.options?.refreshRate || 30) * 1000
+
+    this.servicesSubscription =
+      this.createMinuteAlignedTimer(refreshRate)
+        .pipe(
+          skipWhile(() => !this.opalIceMaker.progressManager && !this.platform.config.options?.homekitControllerNotificationsSecret)
+        )
+        .subscribe(async () => {
+          try {
+            this.platform.debugLog('Running opal services monitoring tasks')
+            // These Notifications only alert in Homekit Controller
+            await this.opalIceMaker.filterMaintenanceManager.getFilterMaintenanceStatus()
+            await this.opalIceMaker.descaleManager.getDescaleStatus()
+
+            if (this.opalIceMaker.progressManager?.hasService()) {
+              const currentProductionValue = await this.opalIceMaker.progressManager.processProductionProgress()
+              this.opalIceMaker.powerManager.turnOffOnProductionLimitSurpassed(currentProductionValue)
+            }
+          } catch (error) {
+            this.platform.errorLog(`Error in service monitoring: ${error}`)
+          }
+        })
+
+    this.platform.debugLog(`Opal services monitor starting in ${this.getTimeUntilNextMinute() / 1000} seconds, Interval: ${refreshRate / 1000} seconds`)
+  }
+
+  startStatusMonitoring(): void {
+    this.stopStatusMonitoring()
+
+    const refreshRate = (this.platform.config.options?.refreshRate || 30) * 1000
+
+    this.statusSubscription =
+      this.createMinuteAlignedTimer(refreshRate)
+        .subscribe(async () => {
+          try {
+            this.platform.debugLog('Running opal status monitoring tasks')
+            await this.opalIceMaker.statusManager.getOpalCurrentStatus()
+          } catch (error) {
+            this.platform.errorLog(`Error in status monitoring: ${error}`)
+          }
+        })
+
+    this.platform.debugLog(`Opal status monitor starting in ${this.getTimeUntilNextMinute() / 1000} seconds, Interval: ${refreshRate / 1000} seconds`)
   }
 
   startSchedulerMonitoring(): void {
-    this.schedulerSubscription = interval(this.opalIceMaker.schedulingManager.schedulerInterval)
-      .pipe(skipWhile(() => !this.platform.config.deviceOptions?.opal?.oplIceProductionSchedule))
+    this.stopSchedulerMonitoring()
+
+    const schedulingInterval = this.opalIceMaker.schedulingManager.schedulerInterval
+    this.schedulerSubscription = this.createMinuteAlignedTimer(schedulingInterval)
+      .pipe(
+        skipWhile(() => !this.platform.config.deviceOptions?.opal?.oplIceProductionSchedule)
+      )
       .subscribe(() => {
-        this.opalIceMaker.schedulingManager.initializeIfIceMakerOnSchedule()
+        try {
+          this.platform.debugLog('Running opal scheduler monitoring tasks')
+          this.opalIceMaker.schedulingManager.initializeIfIceMakerOnSchedule()
+        } catch (error) {
+          this.platform.errorLog(`Error in scheduler monitoring: ${error}`)
+        }
       })
 
-    this.platform.debugLog(`Started ice maker monitoring at 60s intervals`)
+    this.platform.debugLog(`Opal scheduling monitor starting in ${this.getTimeUntilNextMinute() / 1000} seconds, Interval: ${schedulingInterval / 1000} seconds`)
   }
 
   stopSchedulerMonitoring(): void {
@@ -59,6 +115,14 @@ export class OpalMonitorManager extends OpalDeviceBase {
       this.schedulerSubscription.unsubscribe()
       this.schedulerSubscription = null
       this.platform.debugLog('Stopped Schedule Monitoring')
+    }
+  }
+
+  stopStatusMonitoring(): void {
+    if (this.statusSubscription) {
+      this.statusSubscription.unsubscribe()
+      this.statusSubscription = null
+      this.platform.debugLog('Stopped Status Monitoring')
     }
   }
 

--- a/src/devices/OpalIceMaker/index.ts
+++ b/src/devices/OpalIceMaker/index.ts
@@ -60,9 +60,9 @@ export class SmartHQIceMaker extends deviceBase {
 
     this.metadataManager = new OpalMetadataSvcManager(this, platform, accessory, device)
 
-
     this.monitorManager.startServicesMonitoring()
     this.monitorManager.startSchedulerMonitoring()
+    this.monitorManager.startStatusMonitoring()
   }
 
   shutdown(): void {


### PR DESCRIPTION
## :recycle: Current situation

Noticed a couple of issues with the Monitoring. For one, the scheduled start of ice production can happen any time between the 0th and 59th second. Since the scheduler doesn't account for seconds, it would be a better user experience for the intervals to start _minute aligned_, rather than just whenever the server starts.

I also noticed that the opal ice maker status was not being polled if the homekit controller client secret was not provided. Technically HKC provides better notifications but the ice bin full and add water statuses should not require HKC to work. 

Only the Filter Maintenance and Needs Descale Services are explicitly dependent on HKC, because they do not show in the homekit app, and only are notification services.

## :bulb: Proposed solution

Made minute aligned logic, now whenever the server restarts the polling will begin on the next minute.

Also moved the status polling into a separate interval that does not require homekit controller client secret to run.


## :gear: Release Notes

Minute aligned Monitoring.

## :heavy_plus_sign: Additional Information

I tested this line and it appears to work

`if (now >= scheduledTime && now <= triggerWindowEnd) {`

my only reservation is that maybe the second condition should be `now < triggerWindowEnd` but still the ice machine doesn't start again if I stop it within the triggerWindow.

### Testing

BDD as always. :(

### Reviewer Nudging

Should be good to go
