### PR TITLE
fix(air conditioner): preserve decimal precision when converting Celsius to Fahrenheit

### DIFF
--- a/src/devices/airConditioner.ts
+++ b/src/devices/airConditioner.ts
@@ -490,7 +490,7 @@ export class SmartHQAirConditioner extends deviceBase {
 
   public async handleSetCoolingThresholdTemperature(value: CharacteristicValue): Promise<void> {
     try {
-      const targetTemperature = Number.parseInt(value as string, 10)
+      const targetTemperature = Number.parseFloat(value as string)
 
       await this.setTemperature(targetTemperature)
     } catch (cause) {


### PR DESCRIPTION
## :recycle: Current situation

HomeKit sends the AC cooling threshold temperature in Celsius, sometimes with decimals. When converting to Fahrenheit for SmartHQ, this can result in inaccurate values.

## :bulb: Proposed solution

Update the logic to use `parseFloat` instead of `parseInt` when handling Celsius temperatures from HomeKit. This preserves decimal precision during conversion to Fahrenheit, which helps avoid inaccuracies when setting the temperature in SmartHQ.

## :gear: Release Notes

- Improved temperature conversion accuracy by preserving decimal values when receiving Celsius input from HomeKit

### Testing

Manual tests against a supported air conditioner

### Reviewer Nudging

Review code changes - this one is pretty simple.
