### PR TITLE
fix(air conditioner): report all operating modes off when unit is off

### DIFF
--- a/src/devices/airConditioner.ts
+++ b/src/devices/airConditioner.ts
@@ -9,11 +9,7 @@ import type { devicesConfig, SmartHqContext, SmartHqERDResponse } from '../setti
 import axios from 'axios'
 import { interval, startWith } from 'rxjs'
 
-import {
-
-  ERD_TYPES,
-
-} from '../settings.js'
+import { ERD_TYPES } from '../settings.js'
 import { deviceBase } from './device.js'
 
 enum PowerState {
@@ -604,9 +600,17 @@ export class SmartHQAirConditioner extends deviceBase {
 
   public async handleGetOperationMode(mode: OperationMode): Promise<CharacteristicValue> {
     try {
-      const value = await this.getOperationMode()
+      const [powerState, currentOperationMode] = await Promise.all([
+        this.getPowerState(),
+        this.getOperationMode(),
+      ])
 
-      return value === mode
+      // If the air conditioner is off, all modes are off
+      if (powerState === PowerState.OFF) {
+        return false
+      }
+
+      return currentOperationMode === mode
     } catch (cause) {
       const error = new Error(
         `Failed to handle get operation mode ${mode}: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`,


### PR DESCRIPTION
## :recycle: Current situation

Operating mode switch still shows "on" even the the AC unit is turned off

## :bulb: Proposed solution

When the AC unit is turned off, report all operating modes as "off"

## :gear: Release Notes

- Fix operating modes reporting "on" when AC unit is powered off


## :heavy_plus_sign: Additional Information

_If applicable, provide additional context in this section._

### Testing

Manual tests against a supported air conditioner

### Reviewer Nudging

Review code changes - this one is pretty simple.
