### PR TITLE
feat: add Portable AC as supported device

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -266,6 +266,7 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
               await this.createSmartHQIceMaker(userId, device, details, features)
               break
             case 'Air Conditioner':
+            case 'Portable AC':
             case 'Split Air Conditioner':
               await this.createSmartHQAirConditioner(userId, device, details, features)
               break


### PR DESCRIPTION
## :recycle: Current situation

Currently, `Portable AC` is not a supported device.
Solves: #43 

## :bulb: Proposed solution

Add Portable AC as a supported device

## :gear: Release Notes

Add Portable AC as a supported device

## :heavy_plus_sign: Additional Information

Very messy diff:
https://github.com/homebridge-plugins/homebridge-smarthq/compare/v0.3.0...dsafanyuk:homebridge-smarthq:latest

I had to brute force trying to get homebridge to pull my fork. 

I added 2 ERD files that helped me get it working, maybe it can help future device support in the future.
https://github.com/dsafanyuk/homebridge-smarthq/blob/latest/src/devices/erd-api.json
https://github.com/dsafanyuk/homebridge-smarthq/blob/latest/src/devices/erd.json

### Testing

Tested with custom fork:
https://github.com/dsafanyuk/homebridge-smarthq/tree/latest

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_
