### PR TITLE
feat: support hood

### DIFF
--- a/src/devices/hood.ts
+++ b/src/devices/hood.ts
@@ -1,0 +1,353 @@
+/* Copyright(C) 2021-2024, donavanbecker (https://github.com/donavanbecker). All rights reserved.
+ *
+ * hood.ts: @homebridge-plugins/homebridge-smarthq.
+ */
+import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge'
+
+import type { SmartHQPlatform } from '../platform.js'
+import type { devicesConfig, SmartHqContext, SmartHqERDResponse } from '../settings.js'
+
+import axios from 'axios'
+import { interval, startWith } from 'rxjs'
+
+import { ERD_TYPES } from '../settings.js'
+import { deviceBase } from './device.js'
+
+enum FanSpeed {
+  OFF = '00',
+  LOW = '01',
+  MEDIUM = '02',
+  HIGH = '03',
+  BOOST = '04',
+}
+
+enum LightLevel {
+  OFF = '00',
+  DIM = '01',
+  HIGH = '02',
+}
+
+export class SmartHQHood extends deviceBase {
+  private readonly FAN_SVC_NAME = 'HOOD_FAN'
+  private readonly LIGHT_SVC_NAME = 'HOOD_LIGHT'
+  private readonly fanSvc!: Service
+  private readonly lightSvc!: Service
+
+  constructor(
+    protected readonly platform: SmartHQPlatform,
+    protected readonly accessory: PlatformAccessory<SmartHqContext>,
+    protected readonly device: SmartHqContext['device'] & devicesConfig,
+  ) {
+    super(platform, accessory, device)
+
+    this.fanSvc = this.accessory.getService(this.FAN_SVC_NAME)
+      ?? this.accessory.addService(
+        this.platform.Service.Fanv2,
+        `${accessory.displayName} Fan`,
+        this.FAN_SVC_NAME,
+      )
+
+    this.lightSvc = this.accessory.getService(this.LIGHT_SVC_NAME)
+      ?? this.accessory.addService(
+        this.platform.Service.Lightbulb,
+        `${accessory.displayName} Light`,
+        this.LIGHT_SVC_NAME,
+      )
+
+    const fanSwitchSvc = this.accessory.getService('HOOD_FAN_SWITCH')
+    if (fanSwitchSvc) {
+      this.accessory.removeService(fanSwitchSvc)
+    }
+
+    const lightSwitchSvc = this.accessory.getService('HOOD_LIGHT_SWITCH')
+    if (lightSwitchSvc) {
+      this.accessory.removeService(lightSwitchSvc)
+    }
+
+    this.fanSvc
+      .getCharacteristic(this.platform.Characteristic.Active)
+      .onGet(this.handleGetFanActive.bind(this))
+      .onSet(this.handleSetFanActive.bind(this))
+
+    this.fanSvc
+      .getCharacteristic(this.platform.Characteristic.RotationSpeed)
+      .setProps({
+        minValue: 0,
+        maxValue: 100,
+        minStep: 25,
+      })
+      .onGet(this.handleGetFanRotationSpeed.bind(this))
+      .onSet(this.handleSetFanRotationSpeed.bind(this))
+
+    this.lightSvc
+      .getCharacteristic(this.platform.Characteristic.On)
+      .onGet(this.handleGetLightOn.bind(this))
+      .onSet(this.handleSetLightOn.bind(this))
+
+    this.lightSvc
+      .getCharacteristic(this.platform.Characteristic.Brightness)
+      .setProps({
+        minValue: 0,
+        maxValue: 100,
+        minStep: 50,
+      })
+      .onGet(this.handleGetLightBrightness.bind(this))
+      .onSet(this.handleSetLightBrightness.bind(this))
+
+    interval(this.deviceRefreshRate * 1000)
+      .pipe(startWith(0))
+      .subscribe(this.refreshState.bind(this))
+  }
+
+  private getErdValue(erd: string): Promise<string> {
+    return axios
+      .get<SmartHqERDResponse>(`/appliance/${this.accessory.context.device.applianceId}/erd/${erd}`)
+      .then(response => response.data.value)
+      .catch((err) => {
+        const message = axios.isAxiosError(err) && err.response
+          ? `Failed to fetch ERD: ${err.response.data.message}`
+          : `Failed to fetch ERD: ${err instanceof Error ? err.message : 'An unknown error occurred'}`
+        throw new Error(message, { cause: err })
+      })
+  }
+
+  private setErdValue(erd: string, value: string): Promise<void> {
+    return axios
+      .post(`/appliance/${this.accessory.context.device.applianceId}/erd/${erd}`, {
+        kind: 'appliance#erdListEntry',
+        userId: this.accessory.context.userId,
+        applianceId: this.accessory.context.device.applianceId,
+        erd,
+        value,
+      })
+      .then(() => {
+        this.platform.log.debug(`[${this.accessory.displayName}] Set ERD ${erd}=${value}`)
+      })
+      .catch((err) => {
+        const message = axios.isAxiosError(err) && err.response
+          ? `Failed to set ERD ${erd}=${value}: ${err.response.data.message}`
+          : `Failed to set ERD ${erd}=${value}: ${err instanceof Error ? err.message : 'An unknown error occurred'}`
+        throw new Error(message, { cause: err })
+      })
+  }
+
+  private getFanSpeed(): Promise<FanSpeed> {
+    return this.getErdValue(ERD_TYPES.HOOD_FAN_SPEED)
+      .then(value => value as FanSpeed)
+      .catch((err) => {
+        throw new Error(`Failed to get fan speed: ${err instanceof Error ? err.message : 'An unknown error occurred'}`, { cause: err })
+      })
+  }
+
+  private setFanSpeed(value: FanSpeed): Promise<void> {
+    return this.setErdValue(ERD_TYPES.HOOD_FAN_SPEED, value)
+      .catch((err) => {
+        throw new Error(`Failed to set fan speed: ${err instanceof Error ? err.message : 'An unknown error occurred'}`, { cause: err })
+      })
+  }
+
+  private getLightLevel(): Promise<LightLevel> {
+    return this.getErdValue(ERD_TYPES.HOOD_LIGHT_LEVEL)
+      .then(value => value as LightLevel)
+      .catch((err) => {
+        throw new Error(`Failed to get light level: ${err instanceof Error ? err.message : 'An unknown error occurred'}`, { cause: err })
+      })
+  }
+
+  private setLightLevel(value: LightLevel): Promise<void> {
+    return this.setErdValue(ERD_TYPES.HOOD_LIGHT_LEVEL, value)
+      .catch((err) => {
+        throw new Error(`Failed to set light level: ${err instanceof Error ? err.message : 'An unknown error occurred'}`, { cause: err })
+      })
+  }
+
+  private fanSpeedToRotationSpeed(fanSpeed: FanSpeed): number {
+    switch (fanSpeed) {
+      case FanSpeed.OFF:
+        return 0
+      case FanSpeed.LOW:
+        return 25
+      case FanSpeed.MEDIUM:
+        return 50
+      case FanSpeed.HIGH:
+        return 75
+      case FanSpeed.BOOST:
+        return 100
+      default:
+        return 0
+    }
+  }
+
+  private rotationSpeedToFanSpeed(rotationSpeed: number): FanSpeed {
+    if (rotationSpeed === 0) { return FanSpeed.OFF }
+    if (rotationSpeed <= 25) { return FanSpeed.LOW }
+    if (rotationSpeed <= 50) { return FanSpeed.MEDIUM }
+    if (rotationSpeed <= 75) { return FanSpeed.HIGH }
+    return FanSpeed.BOOST
+  }
+
+  private lightLevelToBrightness(lightLevel: LightLevel): number {
+    switch (lightLevel) {
+      case LightLevel.OFF:
+        return 0
+      case LightLevel.DIM:
+        return 50
+      case LightLevel.HIGH:
+        return 100
+      default:
+        return 0
+    }
+  }
+
+  private brightnessToLightLevel(brightness: number): LightLevel {
+    if (brightness === 0) { return LightLevel.OFF }
+    if (brightness <= 50) { return LightLevel.DIM }
+    return LightLevel.HIGH
+  }
+
+  handleGetFanActive(): Promise<CharacteristicValue> {
+    return this.getFanSpeed()
+      .then((fanSpeed) => {
+        const isActive = fanSpeed !== FanSpeed.OFF
+        const value = isActive ? this.platform.Characteristic.Active.ACTIVE : this.platform.Characteristic.Active.INACTIVE
+        this.debugLog(`Get fan active: ${isActive}`)
+        return value
+      })
+      .catch((err) => {
+        this.errorLog(`handleGetFanActive failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  handleSetFanActive(value: CharacteristicValue): Promise<void> {
+    const isActive = value === this.platform.Characteristic.Active.ACTIVE
+    const fanSpeed = isActive ? FanSpeed.LOW : FanSpeed.OFF
+
+    this.debugLog(`Set fan active: ${isActive}`)
+
+    return this.setFanSpeed(fanSpeed)
+      .then(() => {
+        const rotationSpeed = isActive ? 25 : 0
+        this.fanSvc.updateCharacteristic(this.platform.Characteristic.RotationSpeed, rotationSpeed)
+      })
+      .catch((err) => {
+        this.errorLog(`handleSetFanActive failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  handleGetFanRotationSpeed(): Promise<CharacteristicValue> {
+    return this.getFanSpeed()
+      .then((fanSpeed) => {
+        const rotationSpeed = this.fanSpeedToRotationSpeed(fanSpeed)
+        this.debugLog(`Get fan rotation speed: ${rotationSpeed}% (${fanSpeed})`)
+        return rotationSpeed
+      })
+      .catch((err) => {
+        this.errorLog(`handleGetFanRotationSpeed failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  handleSetFanRotationSpeed(value: CharacteristicValue): Promise<void> {
+    const rotationSpeed = value as number
+    const fanSpeed = this.rotationSpeedToFanSpeed(rotationSpeed)
+
+    this.debugLog(`Set fan rotation speed: ${rotationSpeed}% -> ${fanSpeed}`)
+
+    return this.setFanSpeed(fanSpeed)
+      .then(() => {
+        this.fanSvc.updateCharacteristic(this.platform.Characteristic.RotationSpeed, rotationSpeed)
+      })
+      .catch((err) => {
+        this.errorLog(`handleSetFanRotationSpeed failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  handleGetLightOn(): Promise<CharacteristicValue> {
+    return this.getLightLevel()
+      .then((lightLevel) => {
+        const isOn = lightLevel !== LightLevel.OFF
+        this.debugLog(`Get light on: ${isOn}`)
+        return isOn
+      })
+      .catch((err) => {
+        this.errorLog(`handleGetLightOn failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  handleSetLightOn(value: CharacteristicValue): Promise<void> {
+    const isOn = value as boolean
+    const lightLevel = isOn ? LightLevel.DIM : LightLevel.OFF
+
+    this.debugLog(`Set light on: ${isOn}`)
+
+    return this.setLightLevel(lightLevel)
+      .then(() => {
+        const brightness = isOn ? 50 : 0
+        this.lightSvc.updateCharacteristic(this.platform.Characteristic.Brightness, brightness)
+      })
+      .catch((err) => {
+        this.errorLog(`handleSetLightOn failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  handleGetLightBrightness(): Promise<CharacteristicValue> {
+    return this.getLightLevel()
+      .then((lightLevel) => {
+        const brightness = this.lightLevelToBrightness(lightLevel)
+        this.debugLog(`Get light brightness: ${brightness}% (${lightLevel})`)
+        return brightness
+      })
+      .catch((err) => {
+        this.errorLog(`handleGetLightBrightness failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  handleSetLightBrightness(value: CharacteristicValue): Promise<void> {
+    const brightness = value as number
+    const lightLevel = this.brightnessToLightLevel(brightness)
+
+    this.debugLog(`Set light brightness: ${brightness}% -> ${lightLevel}`)
+
+    return this.setLightLevel(lightLevel)
+      .then(() => {
+        this.lightSvc.updateCharacteristic(this.platform.Characteristic.Brightness, brightness)
+      })
+      .catch((err) => {
+        this.errorLog(`handleSetLightBrightness failed: ${err.message}`)
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+      })
+  }
+
+  refreshState(): Promise<void> {
+    return Promise.all([
+      this.getFanSpeed(),
+      this.getLightLevel(),
+    ])
+      .then(([fanSpeed, lightLevel]) => {
+        const isActive = fanSpeed !== FanSpeed.OFF
+        const rotationSpeed = this.fanSpeedToRotationSpeed(fanSpeed)
+        const isOn = lightLevel !== LightLevel.OFF
+        const brightness = this.lightLevelToBrightness(lightLevel)
+
+        this.fanSvc.updateCharacteristic(
+          this.platform.Characteristic.Active,
+          isActive ? this.platform.Characteristic.Active.ACTIVE : this.platform.Characteristic.Active.INACTIVE,
+        )
+        this.fanSvc.updateCharacteristic(this.platform.Characteristic.RotationSpeed, rotationSpeed)
+
+        this.lightSvc.updateCharacteristic(this.platform.Characteristic.On, isOn)
+        this.lightSvc.updateCharacteristic(this.platform.Characteristic.Brightness, brightness)
+
+        this.debugLog(`State refreshed - Fan: ${fanSpeed} (${rotationSpeed}%), Light: ${lightLevel} (${brightness}%)`)
+      })
+      .catch((err) => {
+        this.errorLog(`Failed to refresh state: ${err.message}`)
+      })
+  }
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -17,6 +17,7 @@ import ws from 'ws'
 
 import { SmartHQAirConditioner } from './devices/airConditioner.js'
 import { SmartHQDishWasher } from './devices/dishwasher.js'
+import { SmartHQHood } from './devices/hood.js'
 import { SmartHQOven } from './devices/oven.js'
 import { SmartHQRefrigerator } from './devices/refrigerator.js'
 import getAccessToken, { refreshAccessToken } from './getAccessToken.js'
@@ -282,6 +283,9 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
             case 'Split Air Conditioner':
               await this.createSmartHQAirConditioner(userId, device, details, features)
               break
+            case 'Hood':
+              await this.createSmartHQHood(userId, device, details, features)
+              break
             default:
               await this.warnLog(`Device Type Not Supported: ${device.type}`)
               break
@@ -532,6 +536,42 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
       this.debugLog(`${device.nickname} uuid: ${device.applianceId}`)
 
       // link the accessory to your platform
+      this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory])
+      this.accessories.push(accessory)
+    } else {
+      this.debugErrorLog(`Unable to Register new device: ${JSON.stringify(device.nickname)}`)
+    }
+  }
+
+  private async createSmartHQHood(userId: any, device: any, details: any, features: any) {
+    const uuid = this.api.hap.uuid.generate(device.applianceId)
+
+    const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid)
+
+    if (existingAccessory) {
+      if (!device.hide_device) {
+        existingAccessory.context.device = device
+        existingAccessory.context = { device: { brand: 'GE', ...details, ...features }, userId }
+        existingAccessory.displayName = await this.validateAndCleanDisplayName(device.nickname, 'nickname', device.nickname)
+        existingAccessory.context.device.firmware = device.firmware ?? await this.getVersion()
+        this.api.updatePlatformAccessories([existingAccessory])
+        this.infoLog(`Restoring existing accessory from cache: ${existingAccessory.displayName}`)
+        new SmartHQHood(this, existingAccessory, device)
+        this.debugLog(`${device.nickname} uuid: ${device.applianceId}`)
+      } else {
+        this.unregisterPlatformAccessories(existingAccessory)
+      }
+    } else if (!device.hide_device && !existingAccessory) {
+      this.infoLog(`Adding new accessory: ${device.nickname}`)
+      const accessory = new this.api.platformAccessory<SmartHqContext>(device.nickname, uuid)
+
+      accessory.context.device = device
+      accessory.context = { device: { brand: 'GE', ...details, ...features }, userId }
+      accessory.displayName = await this.validateAndCleanDisplayName(device.nickname, 'nickname', device.nickname)
+      accessory.context.device.firmware = device.firmware ?? await this.getVersion()
+      new SmartHQHood(this, accessory, device)
+      this.debugLog(`${device.nickname} uuid: ${device.applianceId}`)
+
       this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory])
       this.accessories.push(accessory)
     } else {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -288,6 +288,10 @@ export const ERD_TYPES = {
   AIR_CONDITIONER_POWER_STATUS: '0x7A0F' as const,
   AIR_CONDITIONER_TARGET_TEMPERATURE: '0x7003' as const,
   AIR_CONDITIONER_TEMPERATURE_UNIT: '0x0007' as const,
+
+  // Hood/Range Vent
+  HOOD_FAN_SPEED: '0x5B00' as const,
+  HOOD_LIGHT_LEVEL: '0x5B02' as const,
 }
 
 export const ERD_CODES = invert(ERD_TYPES)


### PR DESCRIPTION
---
name: Enhancement
about: Contribute to Plugin through Pull Request
title: "Add Hood/Range Vent Support"
labels: "enhancement"
assignees: "donavanbecker"
---

**Is your enhancement related to a problem? Please describe.**

Currently, the homebridge-smarthq plugin does not support GE SmartHQ Hood/Range Vent devices. Users with these devices cannot
control their range hood fan or light through HomeKit.

**Describe the solution you are adding**

This PR adds complete support for GE SmartHQ Hood/Range Vent devices with the following features:

- **Fan Control**: 5-speed fan control (OFF, LOW, MEDIUM, HIGH, BOOST) via HomeKit Fanv2 service with 25% slider increments
- **Light Control**: 3-level light control (OFF, DIM, HIGH) via HomeKit Lightbulb service with 50% slider increments

The implementation follows the existing device patterns in the codebase and uses the discovered ERD codes:

- `0x5B00`: Fan speed control
- `0x5B02`: Light level control

**Changes Proposed in this Pull Request**

1. **New File**: `src/devices/hood.ts`

   - Complete hood device implementation with fan and light services
   - Promise chain pattern throughout for functional programming style
   - Comprehensive error handling
   - State refresh integration
   - Immediate UI updates after setting values to prevent slider jumping

2. **Modified**: `src/platform.ts`

   - Added `SmartHQHood` import
   - Added `'Hood'` case to device type detection switch
   - Created `createSmartHQHood()` method following existing device registration patterns

3. **Modified**: `src/settings.ts`
   - Added `HOOD_FAN_SPEED: '0x5B00'` ERD type constant
   - Added `HOOD_LIGHT_LEVEL: '0x5B02'` ERD type constant

**Describe alternatives you've considered**

- Initially considered adding separate on/off switches alongside sliders for easier control, but this added unnecessary
  complexity and sync issues. The current slider-only implementation is simpler and more intuitive.
- Considered different refresh rates, but kept the standard 6-minute default to match other devices and avoid excessive API
  calls.

**Additional context**

- ERD codes were discovered through physical device testing
- Tested with physical GE SmartHQ Hood device
- All functionality verified working (fan speeds, light levels, state synchronization)
- No breaking changes to existing functionality
- Follows all existing codebase conventions and patterns

![image](https://github.com/user-attachments/assets/3f6dd2c9-bb3d-4986-a11f-ae823e71bd4d)