### PR TITLE
fix: handle undefined values for fan speed and light level in SmartHQ…

### DIFF
--- a/src/devices/hood.ts
+++ b/src/devices/hood.ts
@@ -342,9 +342,10 @@ export class SmartHQHood extends deviceBase {
       this.getLightLevel(),
     ])
       .then(([fanSpeed, lightLevel]) => {
-        const isActive = fanSpeed !== FanSpeed.OFF
+        // Treat undefined values as OFF to prevent incorrect "on" states
+        const isActive = fanSpeed !== undefined && fanSpeed !== FanSpeed.OFF
         const rotationSpeed = this.fanSpeedToRotationSpeed(fanSpeed)
-        const isOn = lightLevel !== LightLevel.OFF
+        const isOn = lightLevel !== undefined && lightLevel !== LightLevel.OFF
         const brightness = this.lightLevelToBrightness(lightLevel)
 
         this.fanSvc.updateCharacteristic(


### PR DESCRIPTION
…Hood

## :recycle: Current situation

Rangehood light and fan (F&P) is returning undefined from SmartHQ 

```
[1/13/2026, 8:19:06 PM] [SmartHQ] [DEBUG] Rangehood State refreshed - Fan: undefined (0%), Light: undefined (0%)
```

## :bulb: Proposed solution

Update code to equate an undefined response from SmartHQ API as "off" - as this appears to happen when the devices are off. This is fairly isolated and benign change.

## :gear: Release Notes

Rangehood's light and fans that are actually off, will be reported as off.


### Testing

Didn't add tests; didnt see where rangehood was being tested.

### Reviewer Nudging

Changed files.