### PR TITLE
Fix per-device config overrides (hide_device) not being applied

### DIFF
--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -65,7 +65,7 @@ describe('SmartHQPlatform Authentication Error Handling', () => {
   it('should handle getAccessToken failure gracefully', async () => {
     const getAccessToken = await import('./getAccessToken.js')
     const mockGetAccessToken = vi.mocked(getAccessToken.default)
-    
+
     // Simulate getAccessToken throwing "Invalid URL" error
     mockGetAccessToken.mockRejectedValue(new Error('Invalid URL'))
 
@@ -90,7 +90,7 @@ describe('SmartHQPlatform Authentication Error Handling', () => {
       ...mockConfig,
       credentials: undefined,
     }
-    
+
     const platformWithoutCreds = new SmartHQPlatform(mockLog, configWithoutCredentials, mockApi)
     const errorLogSpy = vi.spyOn(platformWithoutCreds as any, 'errorLog').mockResolvedValue(undefined)
 
@@ -99,5 +99,70 @@ describe('SmartHQPlatform Authentication Error Handling', () => {
     expect(errorLogSpy).toHaveBeenCalledWith(
       expect.stringContaining('Username or password is undefined')
     )
+  })
+})
+
+describe('SmartHQPlatform Per-Device Config Merge', () => {
+  let mockApi: API
+  let mockLog: Logging
+  let mockConfig: PlatformConfig
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockLog = {
+      prefix: 'SmartHQ',
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logging
+
+    mockApi = {
+      hap: {
+        Service: {},
+        Characteristic: {},
+        uuid: {
+          generate: vi.fn().mockReturnValue('test-uuid'),
+        },
+      },
+      on: vi.fn(),
+      registerPlatformAccessories: vi.fn(),
+      unregisterPlatformAccessories: vi.fn(),
+      updatePlatformAccessories: vi.fn(),
+    } as unknown as API
+  })
+
+  it('should apply hide_device from config to matching device', async () => {
+    mockConfig = {
+      platform: 'SmartHQ',
+      name: 'SmartHQ',
+      credentials: { username: 'test@example.com', password: 'pass' },
+      devices: [
+        { applianceId: 'appliance-1', hide_device: true },
+      ],
+    }
+
+    const apiDevices = [
+      { applianceId: 'appliance-1', type: 'Dishwasher', nickname: 'My Dishwasher' },
+    ]
+
+    const axios = (await import('axios')).default
+    const mockGet = vi.mocked(axios.get)
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/appliance') {
+        return Promise.resolve({ data: { userId: 'user-1', items: apiDevices } })
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`))
+    })
+
+    const platform = new SmartHQPlatform(mockLog, mockConfig, mockApi)
+
+    // The device is hidden and no existing accessory exists, so createSmartHQDishWasher
+    // should skip it (no register, no warn). We just verify it doesn't crash and
+    // no accessory is registered.
+    await platform.discoverDevices()
+
+    expect(mockApi.registerPlatformAccessories).not.toHaveBeenCalled()
   })
 })

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -32,7 +32,7 @@ import { SmartHQWaterSoftener } from './devices/waterSoftener.js'
 import getAccessToken, { refreshAccessToken } from './getAccessToken.js'
 import { API_URL, ERD_CODES, ERD_TYPES, KEEPALIVE_TIMEOUT, PLATFORM_NAME, PLUGIN_NAME } from './settings.js'
 
-const { find } = pkg
+const { find, keyBy } = pkg
 
 axios.defaults.baseURL = API_URL
 
@@ -311,7 +311,14 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
         const devices = await axios.get('/appliance')
 
         const userId = devices.data.userId
+        const deviceConfigByApplianceId: pkg.Dictionary<devicesConfig | undefined> = keyBy(this.config.devices)
         for (const device of devices.data.items) {
+          // Merge per-device config overrides (hide_device, refreshRate, etc.) from user config
+          const deviceConfig = deviceConfigByApplianceId[device.applianceId]
+          if (deviceConfig?.hide_device) {
+            device.hide_device = deviceConfig.hide_device
+          }
+
           const [{ data: details }, { data: features }] = await Promise.all([
             axios.get(`/appliance/${device.applianceId}`),
             axios.get(`/appliance/${device.applianceId}/feature`),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -43,6 +43,7 @@ export interface credentials {
 }
 
 export interface devicesConfig {
+  applianceId?: string
   firmware: string
   refreshRate?: number
   updateRate?: number


### PR DESCRIPTION
## :recycle: Current situation

The other day I tried to hide my cafe stove from homekit by toggling hide devices! That led me down a rabbit hole and now we're here.

## :bulb: Proposed solution

This change merges properties set in the homebridge config with the device info received from `/appliances`.

- Merge per-device `hide_device` config from this.config.devices onto each device
- Add applianceId?: string to the devicesConfig interface
- Add unit tests for hide_device merge behavior

## :gear: Release Notes

- fix bug where devices were visible to homekit even though `hide_device` was set to true

## :heavy_plus_sign: Additional Information

### Testing

- ran the fix on my local homebridge with npm link. hidden devices were not visible in homekit
- added [a new block](https://github.com/colbyr/homebridge-smarthq/blob/ece7fd3debbffed05d2cfc2de109af9d0eea1630/src/platform.test.ts#L113) to platform.ts to verify the config merging

### Reviewer Nudging

src/platform.ts
