### PR TITLE
fix(airConditioner): prevent crash on API errors

### DIFF
--- a/src/devices/airConditioner.ts
+++ b/src/devices/airConditioner.ts
@@ -379,7 +379,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get active: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -492,7 +492,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get current heater cooler state: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -507,7 +507,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get target heater cooler state: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -570,7 +570,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get current temperature: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -583,7 +583,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get cooling threshold temperature: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -609,7 +609,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get heating threshold temperature: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -646,7 +646,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get fan setting: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -693,7 +693,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get temperature display units: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -723,7 +723,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get filter change indication: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -738,7 +738,7 @@ export class SmartHQAirConditioner extends deviceBase {
       const error = new Error(`Failed to handle get swing mode: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -777,7 +777,7 @@ export class SmartHQAirConditioner extends deviceBase {
       )
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
 
-      throw error
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
     }
   }
 
@@ -952,8 +952,6 @@ export class SmartHQAirConditioner extends deviceBase {
     } catch (cause) {
       const error = new Error(`Failed to refresh state for ${this.accessory.displayName}: ${cause instanceof Error ? cause.message : 'An unknown error occurred'}`, { cause })
       this.platform.log.error(`[${this.accessory.displayName}] ${error.message}`)
-
-      throw error
     }
   }
 


### PR DESCRIPTION
## :recycle: Current situation

When the SmartHQ API returns a bad response (for example a transient `504`), the Air Conditioner accessory crashes the entire child bridge. On restart the API may still be unavailable, so the plugin can't reconnect and the devices stay down until the API recovers and the bridge happens to restart cleanly.

## :bulb: Proposed solution

- The periodic state refresh now logs API errors and continues, instead of re-throwing. The re-thrown error previously became an unhandled promise rejection in the refresh interval, which terminated the child bridge.
- While the API is unavailable, HomeKit now shows the accessory as "No Response" rather than surfacing a generic error.