### PR TITLE
Fix authentication

### DIFF
--- a/src/getAccessToken.ts
+++ b/src/getAccessToken.ts
@@ -73,7 +73,42 @@ export default async function getAccessToken(username: string, password: string)
     }
   }
 
+  const followRedirectsForCode = async (initialLocation: string, maxHops = 10) => {
+    let location: string | undefined | null = initialLocation
+
+    for (let hop = 0; hop < maxHops && location; hop++) {
+      const codeFromLocation = tryExtractCodeFromLocation(location)
+      if (codeFromLocation) {
+        return { code: codeFromLocation, response: null }
+      }
+
+      const resolved = new URL(location, LOGIN_URL).toString()
+      const redirectResponse = await aclient.get(resolved, {
+        maxRedirects: 0,
+        validateStatus: () => true,
+      })
+
+      location = redirectResponse.headers.location
+      if (!location) {
+        return { code: null, response: redirectResponse }
+      }
+    }
+
+    return { code: null, response: null }
+  }
+
   let code = tryExtractCodeFromLocation(res.headers.location)
+  let finalAuthResponse = res
+
+  if (!code && res.headers.location) {
+    const redirectResult = await followRedirectsForCode(res.headers.location)
+    code = redirectResult.code
+
+    if (redirectResult.response) {
+      finalAuthResponse = redirectResult.response
+    }
+  }
+
   if (!code) {
     // Try to handle HTML response pages (MFA or Terms)
     const asyncHandleOkResponse = async (respText: string): Promise<string> => {
@@ -271,8 +306,8 @@ export default async function getAccessToken(username: string, password: string)
     }
 
     // If we have HTML in the response, try to handle it
-    if (res.data && typeof res.data === 'string') {
-      code = await asyncHandleOkResponse(res.data)
+    if (finalAuthResponse.data && typeof finalAuthResponse.data === 'string') {
+      code = await asyncHandleOkResponse(finalAuthResponse.data)
     }
   }
 

--- a/src/getAccessToken.ts
+++ b/src/getAccessToken.ts
@@ -65,7 +65,7 @@ export default async function getAccessToken(username: string, password: string)
     } catch (e) {
       // Handle relative URLs
       try {
-        const full = location.startsWith('/') ? `${LOGIN_URL}${location}` : location
+        const full = new URL(location, LOGIN_URL).toString()
         return new URL(full).searchParams.get('code')
       } catch (e) {
         return null
@@ -106,7 +106,7 @@ export default async function getAccessToken(username: string, password: string)
           const postData = new URLSearchParams(formData)
           const skipResp = await aclient({
             method: 'POST',
-            url: `${LOGIN_URL}/account/active/redirect`,
+            url: new URL('/account/active/redirect', LOGIN_URL).toString(),
             data: postData,
             headers: { 'content-type': 'application/x-www-form-urlencoded' },
             maxRedirects: 0,
@@ -121,7 +121,7 @@ export default async function getAccessToken(username: string, password: string)
 
           // Follow redirect manually if provided
           if (loc) {
-            const resolved = loc.startsWith('/') ? `${LOGIN_URL}${loc}` : loc
+            const resolved = new URL(loc, LOGIN_URL).toString()
             const redirectResp = await aclient.get(resolved, { maxRedirects: 0, validateStatus: () => true })
             const finalLoc = redirectResp.headers.location
             const finalCode = tryExtractCodeFromLocation(finalLoc)
@@ -179,7 +179,7 @@ export default async function getAccessToken(username: string, password: string)
 
             const termsResp = await aclient({
               method: 'POST',
-              url: `${LOGIN_URL}/oauth2/terms/accept`,
+              url: new URL('/oauth2/terms/accept', LOGIN_URL).toString(),
               data: new URLSearchParams(formData),
               headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
               maxRedirects: 0,
@@ -192,7 +192,7 @@ export default async function getAccessToken(username: string, password: string)
               return gotCode
             }
             if (loc) {
-              const resolved = loc.startsWith('/') ? `${LOGIN_URL}${loc}` : loc
+              const resolved = new URL(loc, LOGIN_URL).toString()
               const redirectResp = await aclient.get(resolved, { maxRedirects: 0, validateStatus: () => true })
               const finalCode = tryExtractCodeFromLocation(redirectResp.headers.location)
               if (finalCode) {
@@ -235,7 +235,7 @@ export default async function getAccessToken(username: string, password: string)
 
           const termsResp = await aclient({
             method: 'POST',
-            url: `${LOGIN_URL}/oauth2/terms/accept`,
+            url: new URL('/oauth2/terms/accept', LOGIN_URL).toString(),
             data: new URLSearchParams(formData),
             headers: { 'content-type': 'application/x-www-form-urlencoded', ...headers },
             maxRedirects: 0,
@@ -248,7 +248,7 @@ export default async function getAccessToken(username: string, password: string)
             return gotCode
           }
           if (loc) {
-            const resolved = loc.startsWith('/') ? `${LOGIN_URL}${loc}` : loc
+            const resolved = new URL(loc, LOGIN_URL).toString()
             const redirectResp = await aclient.get(resolved, { maxRedirects: 0, validateStatus: () => true })
             const finalCode = tryExtractCodeFromLocation(redirectResp.headers.location)
             if (finalCode) {


### PR DESCRIPTION
## :recycle: Current situation

Multiple reports (#7 #73 #99) from users regarding "Failed to get Access Token." I experienced this issue myself and traced it. The authentication failure came from building redirect URLs by string concatenation.

LOGIN_URL already ended with /, while redirect paths such as /account/active/redirect and /oauth2/terms/accept also began with /. Code like `${LOGIN_URL}${location}` produced URLs with a double slash in the path: `https://accounts.brillion.geappliances.com//account/active/redirect`

## :bulb: Proposed solution

The fix was to stop concatenating URLs manually and use the URL resolver.
`new URL(location, LOGIN_URL).toString()`
`new URL('/account/active/redirect', LOGIN_URL).toString()`
`new URL('/oauth2/terms/accept', LOGIN_URL).toString()`

This correctly handles:

* Base URLs with or without a trailing slash
* Relative paths with or without a leading slash
* Absolute redirect URLs
* Query strings such as the OAuth authorization code

## :gear: Release Notes

Resolves at least one possible scenario of "Failed to get Access Token" errors.
