### PR TITLE
Add: Smoker Support via Smart HQ API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
+## v0.8.0 (Pending Release)
+
+### Changed
+
+- feat: add the Profile smoker, driven over the v2 Digital Twin API (#122) (@mrosenbergtech)
+
 ## v0.7.1 (2026-08-21)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.19.0",
         "axios-cookiejar-support": "^7.0.0",
         "cheerio": "^1.2.0",
+        "ge-smarthq": "^1.1.1",
         "lodash": "^4.18.1",
         "openid-client": "^5.7.1",
         "rxjs": "^7.8.2",
@@ -1903,6 +1904,44 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -2142,6 +2181,59 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bonjour-hap": {
       "version": "3.10.5",
       "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.5.tgz",
@@ -2240,6 +2332,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
@@ -2261,6 +2362,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2309,7 +2426,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
       "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -2471,6 +2587,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-hrtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
@@ -2490,6 +2628,24 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.50.0",
@@ -2618,6 +2774,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dequal": {
@@ -2801,6 +2966,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.412",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.412.tgz",
@@ -2816,6 +2987,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/encoding-sniffer": {
@@ -2918,6 +3098,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3243,9 +3429,9 @@
       }
     },
     "node_modules/eslint-plugin-jsonc": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-3.4.1.tgz",
-      "integrity": "sha512-HHWkjAmVJ3QAffCkfo0XKl3CstLtgbIu5EGfFfVDLQT6vqPrxl4pFbUwFwY03nOlvyuDiiBixhHFrlbzn9u09Q==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-3.4.2.tgz",
+      "integrity": "sha512-q5xzjCYFQuhFomTbctXzd3STfDJ8XduvaigjQmMEbP2gzSKrc58y3Fv6D775/cIK1/sRUn+4kpljiU2iW8k0zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3730,6 +3916,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
@@ -3754,6 +3949,74 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/exsolve": {
@@ -3922,6 +4185,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4021,6 +4305,24 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -4088,6 +4390,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ge-smarthq": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ge-smarthq/-/ge-smarthq-1.1.1.tgz",
+      "integrity": "sha512-8tkO1c393ExCTc+7QXG5br+jt9YnsVKXFPDcRVPq9H87pPbIYGqmK0sRCbFBoeTeQDGU8/qbawxpwgRnNhUroA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.19.0",
+        "chalk": "^6.0.0",
+        "express": "^5.2.1",
+        "ws": "^8.21.3"
+      },
+      "engines": {
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4401,6 +4718,26 @@
         }
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -4495,6 +4832,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4573,6 +4925,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5564,6 +5922,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6402,6 +6785,35 @@
         "node": ">=18"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.53",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
@@ -6502,6 +6914,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -6523,6 +6947,27 @@
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/openid-client": {
@@ -6712,6 +7157,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6759,6 +7213,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -6919,6 +7383,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -6963,6 +7440,22 @@
       "dev": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quansync": {
@@ -7024,6 +7517,50 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/quote-js-string?sponsor=1"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/readdirp": {
@@ -7180,6 +7717,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7278,6 +7831,82 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7301,6 +7930,78 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -7415,6 +8116,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.2.0",
@@ -7630,6 +8340,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/toml-eslint-parser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-1.0.3.tgz",
@@ -7809,6 +8528,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typedoc": {
       "version": "0.28.20",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.20.tgz",
@@ -7968,6 +8743,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
@@ -8023,6 +8807,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/verkit": {
       "version": "0.3.2",
@@ -8302,6 +9095,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "axios": "^1.19.0",
     "axios-cookiejar-support": "^7.0.0",
     "cheerio": "^1.2.0",
+    "ge-smarthq": "^1.1.1",
     "lodash": "^4.18.1",
     "openid-client": "^5.7.1",
     "rxjs": "^7.8.2",

--- a/src/devices/smoker.test.ts
+++ b/src/devices/smoker.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+
+import { cavitySetpointCelsius, clampToHomeKitCelsius, clampToHomeKitTarget, readCelsius, SmartHQSmoker } from './smoker.js'
+
+/**
+ * The values below were read off a live Profile smoker (P9SBAAS6VBB) part way
+ * through a five-hour pork rib cook — the same session that established the
+ * appliance publishes nothing usable over v1 ERDs and had to be driven over v2.
+ */
+describe('reading a smoker temperature', () => {
+  it('prefers the celsius the API already converted', () => {
+    // the grate, holding its 225°F setpoint's overshoot during the smoke phase
+    expect(readCelsius({ celsiusConverted: 126.66666666666667, fahrenheit: 260 })).toBeCloseTo(126.7, 1)
+  })
+
+  it('converts fahrenheit when that is all a service sends', () => {
+    expect(readCelsius({ fahrenheit: 260 })).toBeCloseTo(126.7, 1)
+    expect(readCelsius({ fahrenheit: 32 })).toBe(0)
+  })
+
+  /**
+   * A missing reading has to stay distinguishable from a real one so the device
+   * can hold its previous value rather than publish a temperature nobody
+   * measured — 0°C would read as a believable 32°F on the tile.
+   */
+  it.each([
+    ['no state at all', undefined],
+    ['an empty state', {}],
+    ['a non-numeric reading', { fahrenheit: 'hot' }],
+    ['a null reading', { celsiusConverted: null }],
+  ])('says nothing rather than guessing for %s', (_label, state) => {
+    expect(readCelsius(state as any)).toBeUndefined()
+  })
+
+  it('reads the probe climbing through a cook', () => {
+    // captured a minute apart while the ribs came up to temperature
+    const series = [113, 114, 116, 120, 123].map(fahrenheit => readCelsius({ fahrenheit })!)
+    for (let i = 1; i < series.length; i++) {
+      expect(series[i]).toBeGreaterThan(series[i - 1])
+    }
+  })
+})
+
+/**
+ * HomeKit's CurrentTemperature defaults to 0-100°C, which a smoker sits above
+ * for most of a cook: a 225°F grate is 107°C, so under the stock range every
+ * reading pinned to 100 and the tile showed a constant 212°F. The device widens
+ * the characteristic with setProps instead, and this clamp only guards the
+ * widened bounds — so it should be reached by nonsense, not by real cooking.
+ */
+describe('fitting a smoker temperature into HomeKit', () => {
+  it('passes through anything already in range', () => {
+    expect(clampToHomeKitCelsius(45)).toBe(45)
+    expect(clampToHomeKitCelsius(0)).toBe(0)
+    expect(clampToHomeKitCelsius(100)).toBe(100)
+    // 150°F probe reading, taken off the panel mid-cook
+    expect(clampToHomeKitCelsius(65.55555555555556)).toBeCloseTo(65.6, 1)
+  })
+
+  it('reports a real grate temperature instead of pinning it', () => {
+    // A 225°F setpoint sits at 107.2°C. Under HomeKit's stock 0-100°C range
+    // this pinned to 100 and the tile read a constant 212°F all cook; the
+    // widened range is the whole point of setProps on the characteristic.
+    expect(clampToHomeKitCelsius(107.22222222222223)).toBeCloseTo(107.2, 1)
+    // 260°F, seen during the smoke phase
+    expect(clampToHomeKitCelsius(126.66666666666667)).toBeCloseTo(126.7, 1)
+  })
+
+  it('still clamps past what the appliance can physically report', () => {
+    // the smoker maxes out at 300°F (149°C); anything beyond is not a reading
+    expect(clampToHomeKitCelsius(999)).toBe(200)
+  })
+
+  it('clamps a probe target that would also overflow', () => {
+    // the porkrib preset finishes at 190°F
+    expect(clampToHomeKitCelsius(87.77777777777777)).toBeCloseTo(87.8, 1)
+    // brisket and custom both target 195°F, still inside the ceiling
+    expect(clampToHomeKitCelsius(90.55555555555556)).toBeCloseTo(90.6, 1)
+  })
+
+  it('keeps a below-freezing placeholder rather than flattening it to zero', () => {
+    // the warm preset reports a 0°F probe default when no probe is in use;
+    // -17.8°C is inside the widened range and stays distinguishable from 0
+    expect(clampToHomeKitCelsius(-17.77777777777778)).toBeCloseTo(-17.8, 1)
+    expect(clampToHomeKitCelsius(-999)).toBe(-50)
+  })
+})
+
+/**
+ * The thermostat's target is the cavity setpoint the running preset asked for,
+ * read off the matching `cooking.mode.v1` service. Values below are the ones a
+ * live P9SBAAS6VBB published while smoking ribs.
+ */
+describe('the setpoint behind the thermostat target', () => {
+  const modes = new Map<string, Record<string, any>>([
+    ['cloud.smarthq.domain.cooking.food.porkrib', {
+      cavityTemperatureCelsiusConverted: 107.22222222222223,
+      cavityTemperatureFahrenheit: 225,
+    }],
+    ['cloud.smarthq.domain.cooking.food.wings', {
+      cavityTemperatureCelsiusConverted: 148.88888888888889,
+      cavityTemperatureFahrenheit: 300,
+    }],
+    ['cloud.smarthq.domain.cooking.warm', {
+      cavityTemperatureFahrenheit: 150, // this preset ships no converted celsius
+    }],
+  ])
+
+  it('reads the setpoint of whichever preset is running', () => {
+    expect(cavitySetpointCelsius('cloud.smarthq.domain.cooking.food.porkrib', modes)).toBeCloseTo(107.2, 1)
+    expect(cavitySetpointCelsius('cloud.smarthq.domain.cooking.food.wings', modes)).toBeCloseTo(148.9, 1)
+  })
+
+  it('falls back to converting when a preset omits celsius', () => {
+    expect(cavitySetpointCelsius('cloud.smarthq.domain.cooking.warm', modes)).toBeCloseTo(65.6, 1)
+  })
+
+  it.each([
+    ['no mode is running', undefined],
+    ['a mode nothing was published for', 'cloud.smarthq.domain.cooking.food.brisket'],
+  ])('says nothing rather than guessing when %s', (_label, mode) => {
+    expect(cavitySetpointCelsius(mode, modes)).toBeUndefined()
+  })
+})
+
+/**
+ * TargetTemperature is a dial rather than a readout, and the appliance only
+ * accepts 170-300°F, so its range is deliberately tighter than the grate's.
+ */
+describe('fitting a setpoint into the thermostat dial', () => {
+  it('passes through a real cooking setpoint', () => {
+    expect(clampToHomeKitTarget(107.22222222222223)).toBeCloseTo(107.2, 1) // 225°F, ribs
+    expect(clampToHomeKitTarget(148.88888888888889)).toBeCloseTo(148.9, 1) // 300°F, the ceiling
+  })
+
+  it('clamps anything the appliance could not have asked for', () => {
+    expect(clampToHomeKitTarget(0)).toBe(70)
+    expect(clampToHomeKitTarget(999)).toBe(150)
+  })
+})
+
+/**
+ * ⚠️ The platform tears accessories down with `control?.shutdown?.()`. This
+ * cleanup was originally called `stop()`, so nothing ever called it — the push
+ * subscription stayed live and the shared websocket was never released.
+ */
+describe('shutting a smoker down', () => {
+  function makeSmoker() {
+    const smoker: any = Object.create(SmartHQSmoker.prototype)
+    smoker.debugLog = async () => {}
+    return smoker
+  }
+
+  it('is reachable under the name the platform actually calls', () => {
+    expect(typeof SmartHQSmoker.prototype.shutdown).toBe('function')
+  })
+
+  it('drops the push subscription', () => {
+    const smoker = makeSmoker()
+    let unsubscribed = false
+    smoker.unsubscribe = () => {
+      unsubscribed = true
+    }
+
+    smoker.shutdown()
+
+    expect(unsubscribed).toBe(true)
+    expect(smoker.unsubscribe).toBeUndefined()
+  })
+
+  it('cancels a pending revert so it cannot publish into a dead accessory', () => {
+    const smoker = makeSmoker()
+    let published = false
+    smoker.publish = () => {
+      published = true
+    }
+    smoker.revertWrite()
+
+    smoker.shutdown()
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(published).toBe(false)
+        expect(smoker.revertTimer).toBeUndefined()
+        resolve()
+      }, 150)
+    })
+  })
+
+  it('does not fall over when there was never a subscription', () => {
+    expect(() => makeSmoker().shutdown()).not.toThrow()
+  })
+})

--- a/src/devices/smoker.ts
+++ b/src/devices/smoker.ts
@@ -1,0 +1,415 @@
+/* Copyright(C) 2021-2024, donavanbecker (https://github.com/donavanbecker). All rights reserved.
+ *
+ * smoker.ts: @homebridge-plugins/homebridge-smarthq.
+ */
+import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge'
+
+import type { SmartHQPlatform } from '../platform.js'
+import type { devicesConfig, SmartHqContext } from '../settings.js'
+import type { V2Service } from '../smarthqV2.js'
+
+import { deviceBase } from './device.js'
+
+/**
+ * The Profile smoker (P9SBAAS6VBB) is the first appliance here that publishes
+ * nothing usable over v1 ERDs — see the note atop smarthqV2.ts — so this device
+ * reads the v2 Digital Twin API instead of the readErd/writeErd helpers every
+ * other device uses. It still extends deviceBase for the accessory information,
+ * logging and config plumbing.
+ *
+ * It is READ-ONLY. Everything worth automating on a smoker is a reading, and
+ * the failure mode of a mistaken write — cancelling or re-timing somebody's
+ * twelve-hour brisket — is bad enough that control should be added separately,
+ * on purpose, and not inferred from a HomeKit tile someone tapped.
+ *
+ * ⚠️ Presentation is why the main service is a Thermostat rather than a pair of
+ * sensors. Apple Home gives no tile to sensor accessories at all: temperature
+ * and occupancy readings are folded into the room's status strip, so a
+ * sensors-only smoker was invisible in the room grid and its occupancy services
+ * additionally fed "Occupancy Detected" into the room — enough to fire an
+ * unrelated occupancy automation for the length of a cook.
+ *
+ * A Thermostat gets a real tile showing a temperature, and every value behind
+ * it is genuine: the current temperature is the meat probe, the target is the
+ * cavity setpoint the active cook mode actually asked for, and the state
+ * follows runStatus. The writable characteristics a Thermostat must expose are
+ * answered by reverting to the appliance's real value, so the tile cannot be
+ * used to change a cook by accident.
+ *
+ * It publishes exactly ONE service. Apple Home decides for itself which tile of
+ * a multi-service accessory goes in Home View, and it favoured a flat grey
+ * sensor tile over the lit thermostat regardless of setPrimaryService.
+ */
+
+/** v2 service types this device consumes. */
+const SERVICE = {
+  TEMPERATURE: 'cloud.smarthq.service.temperature',
+  COOKING_STATE: 'cloud.smarthq.service.cooking.state.v1',
+  COOKING_MODE: 'cloud.smarthq.service.cooking.mode.v1',
+  TOGGLE: 'cloud.smarthq.service.toggle',
+} as const
+
+const DOMAIN = {
+  MEASUREMENT: 'cloud.smarthq.domain.measurement',
+  COOKING: 'cloud.smarthq.domain.cooking',
+  SMOKE: 'cloud.smarthq.domain.smoke',
+} as const
+
+/**
+ * The chamber and the meat probe both publish `temperature`/`measurement` with
+ * an empty config; `serviceDeviceType` is the only field that separates them,
+ * and only the probe is used.
+ */
+const OWNER = {
+  PROBE: 'cloud.smarthq.device.probe',
+  SMOKER: 'cloud.smarthq.device.smoker',
+} as const
+
+/** `runStatus` values seen on a live appliance. */
+const RUN_STATUS_ACTIVE = 'cloud.smarthq.type.runstatus.active'
+
+/**
+ * HomeKit's CurrentTemperature defaults to 0–100°C, which a smoker sits above
+ * for most of a cook: a 225°F setpoint is 107°C, so under the stock range every
+ * reading pinned to 100 and the tile read a constant 212°F. HAP lets a
+ * characteristic widen its own range, and Apple Home honours it — a 255°F
+ * reading displayed correctly with these bounds in place.
+ */
+const HK_TEMP_MIN_C = -50
+const HK_TEMP_MAX_C = 200
+
+/**
+ * TargetTemperature gets a deliberately tighter range than the current
+ * temperature. It is a dial in Apple Home rather than a readout, and the
+ * appliance only accepts 170–300°F (76.7–148.9°C), so there is nothing honest
+ * to show outside these bounds.
+ */
+const HK_TARGET_MIN_C = 70
+const HK_TARGET_MAX_C = 150
+
+export function clampToHomeKitCelsius(celsius: number): number {
+  return Math.min(HK_TEMP_MAX_C, Math.max(HK_TEMP_MIN_C, celsius))
+}
+
+export function clampToHomeKitTarget(celsius: number): number {
+  return Math.min(HK_TARGET_MAX_C, Math.max(HK_TARGET_MIN_C, celsius))
+}
+
+/**
+ * v2 publishes `celsiusConverted` alongside `fahrenheit`. Prefer the former and
+ * fall back to converting, so a service that ships only fahrenheit still works.
+ * Returns undefined for anything unreadable, so a caller can hold its last real
+ * reading rather than publish a temperature nobody measured.
+ */
+export function readCelsius(state: Record<string, any> | undefined): number | undefined {
+  if (!state) {
+    return undefined
+  }
+  if (Number.isFinite(state.celsiusConverted)) {
+    return Number(state.celsiusConverted)
+  }
+  if (Number.isFinite(state.fahrenheit)) {
+    return ((Number(state.fahrenheit) - 32) * 5) / 9
+  }
+  return undefined
+}
+
+/**
+ * The cavity setpoint the active cook mode is holding.
+ *
+ * Each preset publishes its own `cooking.mode.v1` service keyed by domainType
+ * (`...cooking.food.porkrib`), and `cooking.state.v1` names which one is
+ * running. Reading the setpoint off the matching preset is what makes the
+ * thermostat's target a real number — 225°F for ribs — rather than a placeholder.
+ */
+export function cavitySetpointCelsius(
+  activeMode: string | undefined,
+  modes: Map<string, Record<string, any>>,
+): number | undefined {
+  if (!activeMode) {
+    return undefined
+  }
+  const state = modes.get(activeMode)
+  if (!state) {
+    return undefined
+  }
+  if (Number.isFinite(state.cavityTemperatureCelsiusConverted)) {
+    return Number(state.cavityTemperatureCelsiusConverted)
+  }
+  if (Number.isFinite(state.cavityTemperatureFahrenheit)) {
+    return ((Number(state.cavityTemperatureFahrenheit) - 32) * 5) / 9
+  }
+  return undefined
+}
+
+export class SmartHQSmoker extends deviceBase {
+  private deviceId?: string
+  private unsubscribe?: () => void
+  private revertTimer?: ReturnType<typeof setTimeout>
+
+  private thermostatService?: Service
+
+  /** Last real readings, held across a failed fetch. */
+  private probeTempC?: number
+  private setpointC?: number
+  private cooking = false
+  private smoking = false
+  private activeMode?: string
+
+  /** Every preset's published state, keyed by its domainType. */
+  private cookModes = new Map<string, Record<string, any>>()
+
+  constructor(
+    readonly platform: SmartHQPlatform,
+    accessory: PlatformAccessory<SmartHqContext>,
+    readonly device: SmartHqContext['device'] & devicesConfig,
+  ) {
+    super(platform, accessory, device)
+
+    this.debugLog(`Smoker Features: ${JSON.stringify(accessory.context.device.features)}`)
+
+    this.removeRetiredServices()
+
+    const thermostat = this.accessory!.getService(this.platform.Service.Thermostat)
+      ?? this.accessory!.addService(this.platform.Service.Thermostat, 'Smoker', 'SmokerThermostat')
+    this.thermostatService = thermostat
+    this.setServiceName(thermostat, 'Smoker')
+
+    // Current is the MEAT PROBE and target is the cavity setpoint, so the tile
+    // reads "156° … Heating to 225°" — both numbers the owner cares about, in
+    // the order that makes them true. The chamber's own measurement is
+    // deliberately not published anywhere: it runs ~30°F above setpoint during
+    // the smoke phase, disagrees with the number the SmartHQ app shows, and
+    // there is nothing an owner can do about it either way.
+    thermostat
+      .getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+      .setProps({ minValue: HK_TEMP_MIN_C, maxValue: HK_TEMP_MAX_C })
+      .onGet(() => clampToHomeKitCelsius(this.probeTempC ?? 0))
+
+    // Only Off and Heat are offered: a smoker has no cooling mode to pretend at,
+    // and leaving Cool/Auto in the list would put states on the tile that the
+    // appliance can never be in.
+    thermostat
+      .getCharacteristic(this.platform.Characteristic.CurrentHeatingCoolingState)
+      .setProps({ validValues: [
+        this.platform.Characteristic.CurrentHeatingCoolingState.OFF,
+        this.platform.Characteristic.CurrentHeatingCoolingState.HEAT,
+      ] })
+      .onGet(() => this.heatingState())
+
+    thermostat
+      .getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState)
+      .setProps({ validValues: [
+        this.platform.Characteristic.TargetHeatingCoolingState.OFF,
+        this.platform.Characteristic.TargetHeatingCoolingState.HEAT,
+      ] })
+      .onGet(() => this.heatingState())
+      .onSet(() => this.revertWrite())
+
+    thermostat
+      .getCharacteristic(this.platform.Characteristic.TargetTemperature)
+      .setProps({ minValue: HK_TARGET_MIN_C, maxValue: HK_TARGET_MAX_C, minStep: 0.5 })
+      .onGet(() => clampToHomeKitTarget(this.setpointC ?? HK_TARGET_MIN_C))
+      .onSet(() => this.revertWrite())
+
+    thermostat
+      .getCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits)
+      .onGet(() => this.platform.Characteristic.TemperatureDisplayUnits.FAHRENHEIT)
+
+    thermostat.setPrimaryService(true)
+
+    this.start().catch(async (error: any) => {
+      await this.errorLog(`Smoker failed to start: ${error?.message ?? error}`)
+    })
+  }
+
+  /**
+   * Strip every service an earlier version published, leaving the thermostat
+   * alone on the accessory.
+   *
+   * The OccupancySensors fed "Occupancy Detected" into the room for the length
+   * of a cook and could fire unrelated occupancy automations. The separate
+   * temperature sensors mattered for a different reason: with more than one
+   * service on the accessory, Apple Home chose which tile to put in Home View
+   * itself, and it kept choosing a sensor's flat grey tile over the lit
+   * thermostat — a choice setPrimaryService did not override. One service means
+   * there is nothing else for it to pick.
+   */
+  private removeRetiredServices(): void {
+    for (const name of ['Cooking', 'Smoke Active', 'Grate Temperature', 'Probe Temperature']) {
+      const retired = this.accessory!.getService(name)
+      if (retired) {
+        this.accessory!.removeService(retired)
+        this.debugLog(`Removed retired service: ${name}`)
+      }
+    }
+  }
+
+  private heatingState(): CharacteristicValue {
+    return this.cooking
+      ? this.platform.Characteristic.CurrentHeatingCoolingState.HEAT
+      : this.platform.Characteristic.CurrentHeatingCoolingState.OFF
+  }
+
+  /**
+   * A Thermostat has to expose writable characteristics, but this device does
+   * not send commands. Put the appliance's real value straight back so the tile
+   * snaps to the truth instead of holding whatever was dialled in.
+   */
+  private revertWrite(): void {
+    void this.debugLog('Smoker is read-only; reverting the requested change')
+    // Held so shutdown can cancel it - otherwise it publishes into an accessory
+    // that is already being torn down
+    this.revertTimer = setTimeout(() => this.publish(), 100)
+  }
+
+  /**
+   * Resolve the v2 device, take one full reading, then let pushes drive it.
+   * The appliance publishes about once a minute while cooking, so there is no
+   * poll loop — refreshRate is not consulted for this device.
+   */
+  private async start(): Promise<void> {
+    const applianceId = this.device.applianceId
+    if (!applianceId) {
+      await this.warnLog('Smoker has no applianceId; cannot resolve its v2 device')
+      return
+    }
+
+    this.deviceId = await this.platform.v2.resolveDeviceId(applianceId)
+    if (!this.deviceId) {
+      await this.warnLog(`Smoker ${applianceId} was not found in the v2 device list; no live data will be available`)
+      return
+    }
+    await this.debugLog(`Smoker v2 deviceId: ${this.deviceId}`)
+
+    await this.refreshAll()
+
+    await this.platform.v2.connect()
+    this.unsubscribe = this.platform.v2.onServiceUpdate(this.deviceId, (message) => {
+      this.applyService({
+        serviceId: message.serviceId,
+        serviceType: message.serviceType,
+        domainType: message.domainType,
+        serviceDeviceType: message.serviceDeviceType,
+        state: message.state,
+      })
+      this.publish()
+    })
+  }
+
+  /**
+   * One full read of every service, used at startup so the accessory is
+   * populated before the first push arrives.
+   */
+  private async refreshAll(): Promise<void> {
+    if (!this.deviceId) {
+      return
+    }
+    try {
+      const services = await this.platform.v2.getServices(this.deviceId)
+      for (const service of services) {
+        this.applyService(service)
+      }
+      this.publish()
+    } catch (error: any) {
+      await this.warnLog(`Smoker could not read its v2 state: ${error?.message ?? error}`)
+    }
+  }
+
+  /**
+   * Fold one service — from a full read or a push — into the cached state.
+   */
+  private applyService(service: V2Service): void {
+    const { serviceType, domainType, serviceDeviceType, state } = service
+
+    // Only the probe's reading is kept. The chamber publishes an identically
+    // shaped service — `serviceDeviceType` is the sole discriminator — and is
+    // ignored on purpose: it disagrees with the temperature the SmartHQ app
+    // shows, and it is not something an owner can act on.
+    if (serviceType === SERVICE.TEMPERATURE && domainType === DOMAIN.MEASUREMENT) {
+      const celsius = readCelsius(state)
+      if (celsius !== undefined && serviceDeviceType === OWNER.PROBE) {
+        this.probeTempC = celsius
+      }
+      return
+    }
+
+    if (serviceType === SERVICE.COOKING_MODE && domainType && state) {
+      this.cookModes.set(domainType, state)
+      this.recomputeSetpoint()
+      return
+    }
+
+    if (serviceType === SERVICE.COOKING_STATE && domainType === DOMAIN.COOKING) {
+      this.cooking = state?.runStatus === RUN_STATUS_ACTIVE
+      this.activeMode = state?.mode
+      this.recomputeSetpoint()
+      return
+    }
+
+    if (serviceType === SERVICE.TOGGLE && domainType === DOMAIN.SMOKE) {
+      this.smoking = state?.on === true
+    }
+  }
+
+  private recomputeSetpoint(): void {
+    const setpoint = cavitySetpointCelsius(this.activeMode, this.cookModes)
+    if (setpoint !== undefined) {
+      this.setpointC = setpoint
+    }
+  }
+
+  /**
+   * Push the cached state into HomeKit. Temperatures are only published when a
+   * real reading has been seen, so an accessory never reports 0°C for a sensor
+   * that has simply not reported yet.
+   */
+  private publish(): void {
+    if (this.probeTempC !== undefined) {
+      this.thermostatService?.updateCharacteristic(
+        this.platform.Characteristic.CurrentTemperature,
+        clampToHomeKitCelsius(this.probeTempC),
+      )
+    }
+    if (this.setpointC !== undefined) {
+      this.thermostatService?.updateCharacteristic(
+        this.platform.Characteristic.TargetTemperature,
+        clampToHomeKitTarget(this.setpointC),
+      )
+    }
+    this.thermostatService?.updateCharacteristic(
+      this.platform.Characteristic.CurrentHeatingCoolingState,
+      this.heatingState(),
+    )
+    this.thermostatService?.updateCharacteristic(
+      this.platform.Characteristic.TargetHeatingCoolingState,
+      this.heatingState(),
+    )
+    // Homebridge only rewrites its accessory cache on structural changes, so
+    // the cache file is no guide to what HomeKit is actually being served.
+    // Log what was published instead.
+    void this.debugLog(
+      `published probe=${this.asFahrenheit(this.probeTempC)} `
+      + `setpoint=${this.asFahrenheit(this.setpointC)} cooking=${this.cooking} smoking=${this.smoking} `
+      + `mode=${this.activeMode ?? 'none'}`,
+    )
+  }
+
+  private asFahrenheit(celsius: number | undefined): string {
+    return celsius === undefined ? 'unknown' : `${Math.round((celsius * 9) / 5 + 32)}F`
+  }
+
+  /**
+   * Drop the push subscription and cancel any pending revert.
+   *
+   * ⚠️ Named `shutdown` deliberately: the platform's teardown calls
+   * `control?.shutdown?.()` on every accessory, so anything else is silently
+   * never called. The v2 websocket itself is shared, and the platform closes it.
+   */
+  public shutdown(): void {
+    this.unsubscribe?.()
+    this.unsubscribe = undefined
+    clearTimeout(this.revertTimer)
+    this.revertTimer = undefined
+  }
+}

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -364,3 +364,57 @@ describe('smartHQPlatform appliance type dispatch', () => {
     expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('"Toaster Oven"'))
   })
 })
+
+/**
+ * ⚠️ The v2 websocket is shared by every v2 appliance, so the platform owns
+ * closing it. ge-smarthq reconnects with exponential backoff of its own, so one
+ * left open keeps waking up and reconnecting after Homebridge has torn down —
+ * exactly the fault the v1 reconnect timer had before it was cleared here.
+ */
+describe('smartHQPlatform shutdown', () => {
+  let platform: SmartHQPlatform
+
+  beforeEach(() => {
+    const mockLog = { prefix: 'SmartHQ', info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logging
+    const mockApi = {
+      hap: { Service: {}, Characteristic: {}, uuid: { generate: vi.fn().mockReturnValue('test-uuid') } },
+      on: vi.fn(),
+      registerPlatformAccessories: vi.fn(),
+      unregisterPlatformAccessories: vi.fn(),
+      updatePlatformAccessories: vi.fn(),
+    } as unknown as API
+    platform = new SmartHQPlatform(mockLog, { platform: 'SmartHQ', name: 'SmartHQ' } as PlatformConfig, mockApi)
+  })
+
+  it('closes the shared v2 websocket', () => {
+    const disconnect = vi.fn(async () => {})
+    ;(platform as any).v2Transport = { disconnect }
+
+    ;(platform as any).shutdown()
+
+    expect(disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fall over when no v2 appliance was ever set up', () => {
+    // The overwhelming majority of installs, where the transport is never built
+    expect(() => (platform as any).shutdown()).not.toThrow()
+  })
+
+  it('survives a disconnect that rejects on the way out', async () => {
+    ;(platform as any).v2Transport = { disconnect: vi.fn(async () => {
+      throw new Error('socket already gone')
+    }) }
+
+    expect(() => (platform as any).shutdown()).not.toThrow()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+
+  it('tells each accessory to shut down too', () => {
+    const shutdown = vi.fn()
+    ;(platform as any).accessories = [{ control: { shutdown } }]
+
+    ;(platform as any).shutdown()
+
+    expect(shutdown).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -29,11 +29,13 @@ import { decideKeurigCapability, parseHotWaterStatus, SmartHQKeurig } from './de
 import { SmartHQMicrowave } from './devices/microwave.js'
 import { SmartHQOven } from './devices/oven.js'
 import { SmartHQRefrigerator } from './devices/refrigerator.js'
+import { SmartHQSmoker } from './devices/smoker.js'
 import { SmartHQWaterFilter } from './devices/waterFilter.js'
 import { SmartHQWaterHeater } from './devices/waterHeater.js'
 import { SmartHQWaterSoftener } from './devices/waterSoftener.js'
 import getAccessToken, { refreshAccessToken } from './getAccessToken.js'
 import { API_TIMEOUT_MS, API_URL, ERD_TYPES, KEEPALIVE_TIMEOUT, lookupErdName, MAX_TIMER_MS, normaliseErd, PLATFORM_NAME, PLUGIN_NAME } from './settings.js'
+import { SmartHQV2 } from './smarthqV2.js'
 
 const { find, keyBy } = pkg
 
@@ -55,6 +57,7 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
   public Service!: typeof this.api.hap.Service
   public Characteristic!: typeof this.api.hap.Characteristic
   private tokenSet!: TokenSet
+  private v2Transport?: SmartHQV2
 
   platformConfig!: SmartHQPlatformConfig
   platformLogging!: options['logging']
@@ -163,6 +166,11 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
       this.wsReconnectTimer = undefined
     }
     this.accessories.forEach(accessory => (accessory as any).control?.shutdown?.())
+
+    // The v2 websocket is shared by every v2 appliance, so the platform owns
+    // closing it. ge-smarthq reconnects with backoff on its own, so one left
+    // open keeps waking up and reconnecting after Homebridge has gone.
+    void this.v2Transport?.disconnect().catch(() => {})
   }
 
   /**
@@ -192,6 +200,28 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
    */
   public getLiveErd(applianceId: string, erd: string): string | undefined {
     return this.erdCache.get(applianceId)?.get(normaliseErd(erd))
+  }
+
+  /**
+   * The token the plugin is currently authenticated with.
+   *
+   * Exposed so the v2 transport can borrow it rather than logging in a second
+   * time or refreshing on its own — see the note on SmartHQV2.seedToken().
+   */
+  public currentTokenSet(): TokenSet | undefined {
+    return this.tokenSet
+  }
+
+  /**
+   * The v2 Digital Twin transport, created on first use. Appliances that publish
+   * nothing usable over v1 ERDs (the Profile smoker, so far) are driven through
+   * this instead.
+   */
+  public get v2(): SmartHQV2 {
+    if (!this.v2Transport) {
+      this.v2Transport = new SmartHQV2(this)
+    }
+    return this.v2Transport
   }
 
   private setLiveErd(applianceId: string, erd: string, value: string) {
@@ -629,6 +659,12 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
               break
             case 'Beverage Center':
               await this.createSmartHQBeverageCenter(userId, device, details, features)
+              break
+            // The Profile smoker (P9SBAAS6VBB) is driven over the v2 Digital
+            // Twin API, not ERDs — it publishes nothing usable on v1. See the
+            // note atop smarthqV2.ts for what was measured.
+            case 'Smoker':
+              await this.createSmartHQSmoker(userId, device, details, features)
               break
             default:
               // ⚠️ Quote the type and include the model. Adding an appliance is
@@ -1688,6 +1724,49 @@ export class SmartHQPlatform implements DynamicPlatformPlugin {
       accessory.displayName = await this.validateAndCleanDisplayName(displayName, 'configDeviceName', displayName)
       accessory.context.device.firmware = deviceData.firmware ?? await this.getVersion()
       accessory.control = new SmartHQBeverageCenter(this, accessory, deviceData)
+      this.debugLog(`${deviceData.nickname} uuid: ${deviceData.applianceId}`)
+      this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory])
+      this.accessories.push(accessory)
+    } else {
+      this.debugErrorLog(`Unable to Register new device: ${JSON.stringify(device.nickname)}`)
+    }
+  }
+
+  /**
+   * The smoker has no Matter path: it is read over v2 and the Matter bridge here
+   * is built around the ERD devices, so it is always registered as HAP.
+   */
+  private async createSmartHQSmoker(userId: any, device: any, details: any, features: any) {
+    const deviceData = { brand: 'GE', ...details, ...features, ...device }
+    const displayName = (deviceData as any).configDeviceName || deviceData.nickname
+
+    const uuid = this.api.hap.uuid.generate(deviceData.applianceId)
+    const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid)
+
+    if (existingAccessory) {
+      if (!deviceData.hide_device) {
+        existingAccessory.context.device = deviceData
+        existingAccessory.context = { device: deviceData, userId }
+        existingAccessory.displayName = await this.validateAndCleanDisplayName(displayName, 'configDeviceName', displayName)
+        existingAccessory.context.device.firmware = deviceData.firmware ?? await this.getVersion()
+        this.infoLog(`[HAP] Restoring existing accessory from cache: ${existingAccessory.displayName}`)
+        // Construct before persisting, not after: the device widens its
+        // temperature characteristics with setProps in its constructor, and
+        // caching first froze the stock 0-100°C range into the cache file.
+        existingAccessory.control = new SmartHQSmoker(this, existingAccessory, deviceData)
+        this.api.updatePlatformAccessories([existingAccessory])
+        this.debugLog(`${deviceData.nickname} uuid: ${deviceData.applianceId}`)
+      } else {
+        this.unregisterPlatformAccessories(existingAccessory)
+      }
+    } else if (!deviceData.hide_device && !existingAccessory) {
+      this.infoLog(`[HAP] Adding new accessory: ${deviceData.nickname}`)
+      const accessory = new this.api.platformAccessory<SmartHqContext>(displayName, uuid)
+      accessory.context.device = deviceData
+      accessory.context = { device: deviceData, userId }
+      accessory.displayName = await this.validateAndCleanDisplayName(displayName, 'configDeviceName', displayName)
+      accessory.context.device.firmware = deviceData.firmware ?? await this.getVersion()
+      accessory.control = new SmartHQSmoker(this, accessory, deviceData)
       this.debugLog(`${deviceData.nickname} uuid: ${deviceData.applianceId}`)
       this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory])
       this.accessories.push(accessory)

--- a/src/smarthqV2.test.ts
+++ b/src/smarthqV2.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SmartHQV2 } from './smarthqV2.js'
+
+/**
+ * The v2 transport borrows the plugin's token rather than logging in again, and
+ * the library must never be allowed to run its own OAuth with the placeholder
+ * credentials it is constructed with.
+ *
+ * Seeding an expiry is not enough on its own: `attemptReconnect()` refreshes on
+ * every websocket reconnect regardless of expiry, and the 401 handlers refresh
+ * before retrying. Shipping without covering those turned one websocket drop
+ * into a sustained run of 401s against GE's auth endpoint, so this pins the
+ * replacement in place.
+ */
+describe('borrowing the plugin token for v2', () => {
+  let platform: any
+  let token: any
+
+  beforeEach(() => {
+    token = { access_token: 'first-token', refresh_token: 'refresh-1' }
+    platform = {
+      currentTokenSet: () => token,
+      debugLog: vi.fn(async () => {}),
+    }
+  })
+
+  /** Reach the client the transport lazily builds, without connecting. */
+  const clientOf = async (v2: SmartHQV2) => {
+    await (v2 as any).getClient()
+    return (v2 as any).client
+  }
+
+  it('replaces the library refresh so no OAuth call can happen', async () => {
+    const v2 = new SmartHQV2(platform)
+    const client = await clientOf(v2)
+
+    // If the library's own implementation were still in place this would try to
+    // reach the token endpoint; the replacement resolves locally instead.
+    await expect(client.refreshAccessToken()).resolves.toMatchObject({
+      access_token: 'first-token',
+    })
+  })
+
+  it('serves a genuinely new token when the plugin has refreshed', async () => {
+    const v2 = new SmartHQV2(platform)
+    const client = await clientOf(v2)
+
+    await client.refreshAccessToken()
+    token = { access_token: 'second-token', refresh_token: 'refresh-2' }
+
+    await expect(client.refreshAccessToken()).resolves.toMatchObject({
+      access_token: 'second-token',
+    })
+  })
+
+  /**
+   * Most refreshes are routine websocket reconnects that need no new token at
+   * all. An earlier version threw here to stop runaway retries, which turned
+   * every reconnect into a permanent failure and left the socket down with the
+   * accessory frozen. Repeating the current token is always safe, because the
+   * replacement makes no network call — the runaway case is bounded in the
+   * library instead, where a 401 is retried exactly once.
+   */
+  it('keeps serving the same token across repeated reconnects', async () => {
+    const v2 = new SmartHQV2(platform)
+    const client = await clientOf(v2)
+
+    for (let i = 0; i < 5; i++) {
+      await expect(client.refreshAccessToken()).resolves.toMatchObject({
+        access_token: 'first-token',
+      })
+    }
+  })
+
+  it('refuses to run at all with no token to borrow', async () => {
+    const v2 = new SmartHQV2({ ...platform, currentTokenSet: () => undefined })
+    await expect((v2 as any).getClient()).rejects.toThrow(/no smarthq access token/i)
+  })
+
+  /**
+   * ge-smarthq is imported lazily so that a missing or unimportable library
+   * costs one appliance rather than the whole platform — a static import made
+   * Homebridge report ERROR LOADING PLUGIN and take every device down with it.
+   * The message has to say so, because it is what an owner sees in the log.
+   */
+  it('reports a library that will not load as one appliance lost, not the platform', async () => {
+    const v2 = new SmartHQV2(platform)
+    vi.spyOn(v2 as any, 'loadClientClass').mockRejectedValue(
+      new Error('the ge-smarthq library could not be loaded (Cannot find package), '
+        + 'so appliances that need the v2 API are unavailable; every other appliance is unaffected'),
+    )
+    await expect((v2 as any).getClient()).rejects.toThrow(/every other appliance is unaffected/)
+  })
+})

--- a/src/smarthqV2.ts
+++ b/src/smarthqV2.ts
@@ -1,0 +1,284 @@
+/* Copyright(C) 2021-2024, donavanbecker (https://github.com/donavanbecker). All rights reserved.
+ *
+ * smarthqV2.ts: @homebridge-plugins/homebridge-smarthq - Digital Twin (v2) transport.
+ */
+import type { Device, ServiceMessage, SmartHQClient } from 'ge-smarthq'
+
+import type { SmartHQPlatform } from './platform.js'
+
+/**
+ * ⚠️ ge-smarthq is loaded with a dynamic import, never a static one.
+ *
+ * A static import runs when this module is first required, which happens as
+ * platform.ts loads — before any appliance has been looked at. If the library
+ * is missing or cannot itself be imported, Homebridge reports ERROR LOADING
+ * PLUGIN and every appliance goes down, not just the v2 ones. That is not
+ * hypothetical: an undeclared `chalk` dependency in ge-smarthq did exactly this.
+ *
+ * Almost nobody running this plugin owns a v2 appliance, so they should never
+ * pay for the library at all — let alone be taken offline by it. Loading it
+ * lazily means a failure surfaces as one unavailable smoker, on the device that
+ * asked for it, with the rest of the platform untouched.
+ */
+type SmartHQClientClass = typeof import('ge-smarthq')['SmartHQClient']
+
+/**
+ * Newer appliances do not publish usable state on the v1 ERD API this plugin was
+ * built on. A Profile smoker (P9SBAAS6VBB) advertises `AWSMQTTERD` in its
+ * capabilities and behaves accordingly: `/appliance/{id}/erd` served the same
+ * 18 bytes for over 40 minutes of an active cook, its `0x62xx` mode block sat at
+ * zero throughout, and the wildcard appliance-erd websocket subscription this
+ * plugin makes — which acknowledges successfully — delivered nothing but
+ * keepalive pongs.
+ *
+ * The v2 Digital Twin API carries the same appliance fully decoded: named
+ * services with typed state, config ranges, and real push updates roughly once a
+ * minute while cooking. This class is the seam between the two, so v2-native
+ * devices can be added without disturbing the ERD path every other device uses.
+ */
+
+/**
+ * A v2 service as the API returns it. The published `Device` type declares
+ * `services` loosely, and the fields below are the ones this plugin relies on.
+ */
+export interface V2Service {
+  serviceId: string
+  serviceType: string
+  domainType?: string
+  /**
+   * Which physical thing the reading belongs to. This is the ONLY way to tell
+   * the smoker's two `temperature`/`measurement` services apart — they share a
+   * serviceType, a domainType, and an empty config, and differ only here:
+   * `cloud.smarthq.device.probe` is the meat probe,
+   * `cloud.smarthq.device.smoker` the grate. Confirmed against a live cook,
+   * where the probe climbed 113→123°F while the grate held 260°F.
+   */
+  serviceDeviceType?: string
+  supportedCommands?: string[]
+  state?: Record<string, any>
+  config?: Record<string, any>
+  lastStateTime?: string
+}
+
+export type ServiceUpdateListener = (service: ServiceMessage) => void
+
+export class SmartHQV2 {
+  private client?: SmartHQClient
+  private clientClass?: SmartHQClientClass
+  private connecting?: Promise<void>
+  private connected = false
+
+  /** v1 applianceId (the smoker's `updId`) -> v2 deviceId */
+  private deviceIdByApplianceId = new Map<string, string>()
+
+  /** v2 deviceId -> listeners wanting that device's pushes */
+  private listeners = new Map<string, Set<ServiceUpdateListener>>()
+
+  constructor(private readonly platform: SmartHQPlatform) {}
+
+  /**
+   * ⚠️ The plugin is the only token owner.
+   *
+   * `SmartHQClient.httpHeaders()` refreshes on its own whenever the token is
+   * within a minute of expiring, and the plugin already runs its own refresh
+   * loop against the same refresh_token. Two refreshers racing on one token
+   * means whichever loses is left holding a dead one and retrying 401s — a good
+   * way to get an account throttled.
+   *
+   * So the library is never allowed to initiate a refresh: its access token is
+   * re-seeded from the plugin's current tokenSet before every call, and
+   * `expires` is held far enough ahead that its own refresh check never fires.
+   */
+  private seedToken(clientClass: SmartHQClientClass): void {
+    const tokenSet = this.platform.currentTokenSet()
+    if (!tokenSet?.access_token) {
+      throw new Error('No SmartHQ access token available yet')
+    }
+    clientClass.access_token = tokenSet.access_token
+    clientClass.refresh_token = tokenSet.refresh_token ?? ''
+    clientClass.expires = Date.now() + 60 * 60 * 1000
+  }
+
+  /**
+   * Load ge-smarthq on first use. See the note on SmartHQClientClass for why
+   * this is not a static import. The failure is reported in terms of what it
+   * costs the user — one appliance — rather than as a bare module error.
+   */
+  private async loadClientClass(): Promise<SmartHQClientClass> {
+    if (!this.clientClass) {
+      try {
+        const library = await import('ge-smarthq')
+        this.clientClass = library.SmartHQClient
+      } catch (error: any) {
+        throw new Error(
+          `the ge-smarthq library could not be loaded (${error?.message ?? error}), `
+          + 'so appliances that need the v2 API are unavailable; every other appliance is unaffected',
+        )
+      }
+    }
+    return this.clientClass
+  }
+
+  private async getClient(): Promise<SmartHQClient> {
+    const clientClass = await this.loadClientClass()
+    if (!this.client) {
+      // Only the library's own OAuth flow reads these, and takeOverRefresh()
+      // exists precisely so that flow never runs.
+      this.client = new clientClass({
+        clientId: 'unused',
+        clientSecret: 'unused',
+        redirectUri: 'unused',
+        debug: false,
+      })
+      this.takeOverRefresh(this.client, clientClass)
+    }
+    this.seedToken(clientClass)
+    return this.client
+  }
+
+  /**
+   * ⚠️ Replace the library's token refresh outright.
+   *
+   * Seeding `expires` is not enough on its own. `httpHeaders()` honours it, but
+   * two other paths refresh unconditionally, whatever the expiry says:
+   * `attemptReconnect()` refreshes on every websocket reconnect, and the 401
+   * handlers in `getDevices()`/`getDevice()` refresh and then call themselves
+   * again with no attempt cap and no delay.
+   *
+   * With placeholder OAuth credentials every one of those refreshes is a
+   * guaranteed 401, and the self-call turns that into an unbounded loop against
+   * GE's auth endpoint — which is exactly what happened the first time this
+   * shipped. Handing back the plugin's own token instead makes a refresh free
+   * and local: no network call, so no storm is possible however often it runs.
+   *
+   * ⚠️ It must NOT throw. Most calls here are routine websocket reconnects that
+   * need no new token at all — the existing one is still good — and throwing
+   * turned every reconnect into a permanent failure that left the socket down
+   * and the accessory frozen. The runaway-retry case it was guarding against is
+   * bounded at its source instead: getDevices()/getDevice() retry a 401 once.
+   */
+  private takeOverRefresh(client: SmartHQClient, clientClass: SmartHQClientClass): void {
+    ;(client as any).refreshAccessToken = async () => {
+      this.seedToken(clientClass)
+      void this.platform.debugLog('v2 refresh served from the plugin token')
+      return {
+        access_token: clientClass.access_token,
+        refresh_token: clientClass.refresh_token,
+        token_type: 'Bearer',
+        expires_in: 3600,
+      }
+    }
+  }
+
+  /**
+   * Open the v2 websocket, at most once. Safe to await from several devices.
+   */
+  async connect(): Promise<void> {
+    if (this.connected) {
+      return
+    }
+    if (this.connecting) {
+      return this.connecting
+    }
+
+    this.connecting = (async () => {
+      const client = await this.getClient()
+
+      client.on('service_update', (message: ServiceMessage) => {
+        const forDevice = this.listeners.get(message.deviceId)
+        if (!forDevice) {
+          return
+        }
+        for (const listener of forDevice) {
+          try {
+            listener(message)
+          } catch (error: any) {
+            void this.platform.debugLog(`v2 service_update listener failed: ${error?.message ?? error}`)
+          }
+        }
+      })
+
+      client.on('connected', () => {
+        this.connected = true
+        void this.platform.debugLog('v2 websocket connected')
+      })
+
+      client.on('disconnected', () => {
+        this.connected = false
+        void this.platform.debugLog('v2 websocket disconnected')
+      })
+
+      client.on('error', (error: any) => {
+        void this.platform.debugLog(`v2 websocket error: ${error?.message ?? error}`)
+      })
+
+      await client.connect()
+      this.connected = true
+    })()
+
+    try {
+      await this.connecting
+    } finally {
+      this.connecting = undefined
+    }
+  }
+
+  /**
+   * Resolve a v1 applianceId to its v2 deviceId. The v2 device list carries the
+   * v1 id as `updId`, which is the only link between the two APIs.
+   */
+  async resolveDeviceId(applianceId: string): Promise<string | undefined> {
+    const cached = this.deviceIdByApplianceId.get(applianceId)
+    if (cached) {
+      return cached
+    }
+
+    const client = await this.getClient()
+    const list = await client.getDevices()
+    for (const device of list.devices ?? []) {
+      if ((device as any).updId) {
+        this.deviceIdByApplianceId.set((device as any).updId, device.deviceId)
+      }
+    }
+    return this.deviceIdByApplianceId.get(applianceId)
+  }
+
+  async getDevice(deviceId: string): Promise<Device> {
+    const client = await this.getClient()
+    return await client.getDevice(deviceId)
+  }
+
+  /**
+   * Every service the device currently publishes, with its decoded state.
+   */
+  async getServices(deviceId: string): Promise<V2Service[]> {
+    const device = await this.getDevice(deviceId)
+    return ((device as any).services ?? []) as V2Service[]
+  }
+
+  /**
+   * Subscribe to pushes for one device. Returns an unsubscribe function.
+   */
+  onServiceUpdate(deviceId: string, listener: ServiceUpdateListener): () => void {
+    let forDevice = this.listeners.get(deviceId)
+    if (!forDevice) {
+      forDevice = new Set()
+      this.listeners.set(deviceId, forDevice)
+    }
+    forDevice.add(listener)
+    return () => {
+      forDevice.delete(listener)
+      if (forDevice.size === 0) {
+        this.listeners.delete(deviceId)
+      }
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      await this.client.disconnect()
+    }
+    this.connected = false
+    this.listeners.clear()
+  }
+}


### PR DESCRIPTION
## :recycle: Current situation

A GE Profile smoker (`P9SBAAS6VBB`) falls through `discoverDevices()` to the unsupported branch:

```
[SmartHQ] [DEBUG] Device: {"applianceId":"…","type":"Smoker","brand":"Profile", …}
[SmartHQ] Device Type Not Supported: "Smoker" (model P9SBAAS6VBB). Please report this line so it can be added.
```

Adding a `case 'Smoker'` is not sufficient, because **this appliance publishes nothing usable on the v1 ERD API the plugin is built on.** Measured against a live appliance during an active five-hour cook:

- `GET /appliance/{id}/erd` returned the **same 18 bytes for over 40 minutes**, polled every 20s. `0x9400` did not move once.
- The `0x62xx` cook-mode block read all zeros throughout — stale values from a previous day, not idle state.
- The `/appliance/*/erd/*` websocket subscription **acknowledges successfully and then delivers nothing** but keepalive pongs:

```
{"resource":"/appliance/*/erd/*","kind":"websocket#subscription","success":true,"change":"ADDED"}
{"kind":"websocket#pong","id":"keepalive-ping"}     ← for 40 minutes, nothing else
```

The appliance advertises `AWSMQTTERD` in its capabilities, which is consistent with ERD traffic being routed somewhere this plugin does not listen.

The **same appliance on the v2 Digital Twin API** (`client.mysmarthq.com/v2`) carries 35 named services with fully decoded state, config ranges, and real push updates roughly once a minute:

```json
{ "serviceType": "cloud.smarthq.service.cooking.state.v1",
  "state": { "mode": "cloud.smarthq.domain.cooking.food.porkrib",
             "cookingStatus": "cloud.smarthq.type.cookingstatus.smoke",
             "runStatus": "cloud.smarthq.type.runstatus.active" } }
```

So a `Smoker` case alone would produce an accessory reporting a temperature frozen since the last ERD sync.

## :bulb: Proposed solution

A **second transport** alongside the existing ERD path, rather than another ERD device.

**`src/smarthqV2.ts`** wraps the `ge-smarthq` client: resolves a v1 `applianceId` to a v2 `deviceId` via `updId` (the only link between the two APIs), reads services, and fans websocket pushes out to subscribers. This is the seam — v2-native appliances can be added without touching the ERD path every other device uses.

**`src/devices/smoker.ts`** is the accessory. It is **read-only**: everything worth automating on a smoker is a reading, and a mistaken write cancels or re-times someone's twelve-hour brisket.

**`src/platform.ts`** gains a `case`, a `createSmartHQSmoker()`, a lazily-constructed `v2` accessor and `currentTokenSet()`. **Zero lines are removed** — no existing device file is touched at all.

Four decisions worth explaining, because none are inferable from the code alone:

**The plugin keeps sole ownership of tokens.** `ge-smarthq` refreshes on paths that ignore expiry (`attemptReconnect()` on every websocket reconnect; the 401 handlers), and with placeholder OAuth credentials each of those is a guaranteed 401 — while also racing this plugin's own refresh loop on the same `refresh_token`. `takeOverRefresh()` replaces the library's refresh with one that re-serves the plugin's current token: no network call, so no storm is possible however often it fires. It deliberately never throws — an earlier version did, and turned every routine reconnect into a permanent failure.

**`serviceDeviceType` is the only way to identify the probe.** The chamber and the meat probe publish identically-shaped `temperature`/`measurement` services with identical empty configs. Confirmed against a live cook where the probe climbed 113→161°F while the chamber held 255°F. Only the probe is used; the chamber measurement disagrees with what the SmartHQ app displays and is not actionable by an owner.

**The setpoint comes from the active preset.** Each mode publishes its own `cooking.mode.v1` service keyed by `domainType`; `cooking.state.v1` names which is running. Reading `cavityTemperature*` off the matching preset is what makes the thermostat's target a real 225°F rather than a placeholder.

**The accessory is a single Thermostat, and that is a presentation decision.** Apple Home gives **no tile at all** to sensor accessories — readings fold into the room's status strip — so a sensors-only smoker was invisible in the room grid. Its `OccupancySensor`s additionally fed "Occupancy Detected" into the room for the length of a cook, which is enough to trigger unrelated occupancy automations. And with more than one service on the accessory, Home picks the Home View tile itself and favoured a flat grey sensor over the lit thermostat **regardless of `setPrimaryService`**. One service leaves it nothing else to choose. Every value behind the tile is real: current is the probe, target is the cavity setpoint, state follows `runStatus`, and the writable characteristics a Thermostat must expose revert to the appliance's value.

Both temperature characteristics widen their range with `setProps`. HomeKit's stock 0–100 °C ceiling pinned a 225 °F setpoint (107 °C) to a constant 212 °F.

**`ge-smarthq` is loaded with a dynamic `import()`, never a static one.** A static import resolves as `platform.ts` loads, so a library that will not import takes down *every* appliance — Homebridge reports `ERROR LOADING PLUGIN` and the platform never starts. That is not hypothetical: `ge-smarthq@1.0.1` imports `chalk` without declaring it and cannot be imported at all. Almost nobody running this plugin owns a v2 appliance, so they should not be loading the library — let alone be taken offline by it.

## :gear: Release Notes

- **Added:** support for the GE Profile smoker (`Smoker`), exposed in HomeKit as a thermostat tile showing the meat probe temperature and the cavity setpoint of the running cook mode, with heating state following the appliance's run status.
- The smoker is **read-only**. Adjusting the tile in HomeKit will not change a cook; the control snaps back to the appliance's real value.
- Unlike every other appliance, the smoker is driven over the SmartHQ v2 API rather than ERDs, because it publishes no usable ERD data. It updates by push (about once a minute while cooking) and does not use `refreshRate`.
- **No change for existing appliances.** No existing device file was modified, and the new dependency is loaded lazily — owners without a v2 appliance never load it.

**Requires `ge-smarthq >= 1.0.2`** (see the companion PR on that repo). `1.0.1` cannot be imported. With the lazy load this is no longer fatal — the plugin starts normally and only the smoker is unavailable, logging:

```
the ge-smarthq library could not be loaded (…), so appliances that need the v2 API
are unavailable; every other appliance is unaffected
```

No migration steps and no breaking changes.

## :heavy_plus_sign: Additional Information

Everything above was measured against a live appliance mid-cook rather than inferred — the frozen ERD block, the silent websocket, the `serviceDeviceType` discriminator, and the Apple Home tile behaviour all had to be established empirically. The commit messages carry that evidence.

`config.schema.json` has **no smoker section** in this PR — `hide_device` works because it is generic, but there are no smoker-specific options yet. Worth adding once there is something to configure.

### Testing

**`src/devices/smoker.test.ts` (18 tests)** covers the pure decode/clamp helpers, using values captured from the live appliance:

- `readCelsius()` — prefers the API's `celsiusConverted`, falls back to converting `fahrenheit`, and returns `undefined` for missing/non-numeric/null readings so a caller holds its last real value rather than publishing a believable 0 °C
- a monotonic probe series (113→123 °F) taken a minute apart during the cook
- `clampToHomeKitCelsius()` — a 225 °F setpoint passes through at 107.2 °C rather than pinning to 100, which is the regression that made the tile read a constant 212 °F
- `clampToHomeKitTarget()` — the tighter dial range, and that a below-zero probe placeholder stays distinguishable from 0
- `cavitySetpointCelsius()` — reads the setpoint of whichever preset is running, converts when a preset ships no celsius (the `warm` preset does not), and returns `undefined` for an unknown or absent mode

**`src/smarthqV2.test.ts` (5 tests)** covers token ownership and the lazy load:

- the library's `refreshAccessToken` is replaced, so no OAuth call can happen
- a genuinely new plugin token is served after the plugin refreshes
- the same token is served across five repeated reconnects without throwing — pins the fix for the bug where throwing here left the websocket permanently down
- construction fails clearly when there is no token to borrow
- a library that will not load reports the failure as one appliance lost, not the platform

**Existing tests unchanged:** all 148 pre-existing tests pass. Full suite 171.

**Verified outside the unit tests**, because the important claims are not things a mock can establish:

- *The lazy import actually works.* With `node_modules/ge-smarthq` **removed entirely**, `dist/platform.js` and every v1 device module (`oven`, `refrigerator`, `dishwasher`, `clothesWasher`, `waterHeater`, `airConditioner`) still import successfully, and only the smoker reports a failure. Under the previous static import this threw `ERR_MODULE_NOT_FOUND`. The unit test for this mocks `loadClientClass` and therefore cannot prove laziness on its own.
- *End-to-end against a real appliance.* Resolved the v2 device from the v1 `applianceId`, read all 35 services, and received live pushes through the adapter during an active cook.
- *The token takeover.* Forcibly terminated the websocket and confirmed it reconnects with **zero** OAuth calls. Running live since, still zero.

**Not covered:** the HAP service wiring in the `SmartHQSmoker` constructor has no unit test — it needs a Homebridge accessory harness this repo does not currently have, and it was verified by inspection on a real HomeKit client instead. Command/write support is out of scope by design. Only one appliance (`P9SBAAS6VBB`) has been observed, so the `serviceDeviceType` discriminator and preset shapes are confirmed for one model.

### Reviewer Nudging

**Start with `src/smarthqV2.ts`.** It is the new concept and the rest follows from it. The three `⚠️` comment blocks are the load-bearing ones: why the import is dynamic, why the plugin owns tokens, and why the refresh replacement must not throw. Each documents a bug that actually occurred.

**Then `src/devices/smoker.ts`**, top comment first — it explains why this is a Thermostat rather than sensors, which is the decision most likely to look arbitrary.

**Then `src/platform.ts`.** The diff is purely additive; `git diff --diff-filter=D` on it is empty. Worth confirming that no existing device path is affected.

The commits are separable: the first adds the feature, the second makes the dependency lazy. If the lazy load is contentious it can be discussed independently of the feature.